### PR TITLE
Functionality for creation of duplicate sparks

### DIFF
--- a/web/app/controllers/v1/sparks_controller.rb
+++ b/web/app/controllers/v1/sparks_controller.rb
@@ -74,31 +74,19 @@ class V1::SparksController < ApplicationController
     end
   end
 
-  # PUT /sparks/1
-  # PUT /sparks/1.json
-  def update
-    @spark = Spark.find(params[:id])
-    
-    respond_to do |format|
-      if @spark.update_attributes(params[:spark])
-        format.html { redirect_to @spark, :notice => 'Spark was successfully updated.' }
-        format.json { head :no_content }
-      else
-        format.html { render :action => "edit" }
-        format.json { render :json => @spark.errors, :status => :unprocessable_entity }
-      end
-    end
-  end
-
   # DELETE /sparks/1
   # DELETE /sparks/1.json
   def destroy
     @spark = Spark.find(params[:id])
-    @spark.destroy
-
-    respond_to do |format|
-      format.html { redirect_to sparks_url }
-      format.json { head :no_content }
+    user = User.find_by_name(params[:username])
+    
+    if @spark && user && @spark.users.include?(user)
+      @spark.users.delete(user)
+      
+      respond_to do |format|
+        format.html { redirect_to sparks_url }
+        format.json { render :json => @spark, :status => :ok }
+      end
     end
   end
 end

--- a/web/app/controllers/v1/sparks_controller.rb
+++ b/web/app/controllers/v1/sparks_controller.rb
@@ -54,6 +54,15 @@ class V1::SparksController < ApplicationController
         
           format.html { redirect_to @spark, :notice => 'Spark was successfully created.' }
           format.json { render :json => @spark, :status => :created, :location => ["v1", @spark] }
+        elsif @spark.duplicate?
+          @spark = Spark.find_by_content_hash(@spark.content_hash)
+          
+          unless(@spark.users.include?(user))
+            @spark.users << user
+          end
+          
+          format.html { render :action => "new" }
+          format.json { render :json => @spark, :status => :accepted }
         else
           format.html { render :action => "new" }
           format.json { render :json => @spark.errors, :status => :unprocessable_entity }

--- a/web/app/controllers/v1/sparks_controller.rb
+++ b/web/app/controllers/v1/sparks_controller.rb
@@ -62,7 +62,7 @@ class V1::SparksController < ApplicationController
           end
           
           format.html { render :action => "new" }
-          format.json { render :json => @spark, :status => :accepted }
+          format.json { render :json => @spark, :status => :ok }
         else
           format.html { render :action => "new" }
           format.json { render :json => @spark.errors, :status => :unprocessable_entity }

--- a/web/app/models/spark.rb
+++ b/web/app/models/spark.rb
@@ -35,6 +35,10 @@ class Spark < ActiveRecord::Base
     return json
   end
   
+  def duplicate?
+    return (self.errors.to_hash.length == 1) && (self.errors.to_hash.keys[0] == :content_hash)
+  end
+  
   private
   
     def hash_content

--- a/web/config/routes.rb
+++ b/web/config/routes.rb
@@ -6,7 +6,7 @@ Steamnet::Application.routes.draw do
       
       resources :tags, :only => [:index, :show]
       resources :comments, :except => [:new, :edit]
-      resources :sparks, :except => [:new, :edit]
+      resources :sparks, :except => [:new, :edit, :update]
       resources :users, :except => [:new, :edit]
       resources :ideas, :except => [:new, :edit]
       
@@ -19,7 +19,7 @@ Steamnet::Application.routes.draw do
 end
 
 #== Route Map
-# Generated on 11 Jun 2013 14:55
+# Generated on 15 Jun 2013 13:59
 #
 #      v1_tag GET    /api/v1/tags/:id(.:format)     v1/tags#show
 # v1_comments GET    /api/v1/comments(.:format)     v1/comments#index
@@ -30,7 +30,6 @@ end
 #   v1_sparks GET    /api/v1/sparks(.:format)       v1/sparks#index
 #             POST   /api/v1/sparks(.:format)       v1/sparks#create
 #    v1_spark GET    /api/v1/sparks/:id(.:format)   v1/sparks#show
-#             PUT    /api/v1/sparks/:id(.:format)   v1/sparks#update
 #             DELETE /api/v1/sparks/:id(.:format)   v1/sparks#destroy
 #    v1_users GET    /api/v1/users(.:format)        v1/users#index
 #             POST   /api/v1/users(.:format)        v1/users#create

--- a/web/spec/controllers/v1/sparks_controller_spec.rb
+++ b/web/spec/controllers/v1/sparks_controller_spec.rb
@@ -1,5 +1,125 @@
 require 'spec_helper'
 
 describe V1::SparksController do
-
+  
+  describe "GET 'index'" do
+    
+    before(:each) do
+      @sparks = []
+      
+      20.times do
+        @sparks << FactoryGirl.create(:spark)
+      end
+      
+      @sparks.reverse!
+    end
+    
+    it "is successful" do
+      get :index, :format => 'json'
+      response.should be_success
+    end
+    
+    it "returns the correct sparks" do
+      get :index, :format => 'json'
+      response.body.should == @sparks.to_json
+    end
+    
+    it "limits the sparks correctly" do
+      get :index, :format => 'json', :limit => 10
+      response.body.should == @sparks.take(10).to_json
+    end
+    
+  end
+  
+  describe "GET 'show'" do
+    
+    before(:each) do
+      @spark = FactoryGirl.create(:spark)
+    end
+    
+    it "is successful" do
+      get :show, :id => @spark, :format => 'json'
+      response.should be_success
+    end
+    
+    it "returns the correct spark" do
+      get :show, :id => @spark, :format => 'json'
+      response.body.should == @spark.to_json
+    end
+    
+  end
+  
+  describe "POST 'create'" do
+    
+    before(:each) do
+      @user = FactoryGirl.create(:user)
+      
+      @attr = {
+        :spark_type   => "I",
+        :content_type => "L",
+        :content      => "http://google.com/"
+      }
+    end
+    
+    describe "for a new valid spark" do
+      
+      it "is successful" do
+        post :create, :spark => @attr, :format => 'json', :username => @user.name
+        response.should be_success
+      end
+    
+      it "should create the spark" do
+        expect {
+          post :create, :spark => @attr, :format => 'json', :username => @user.name
+        }.to change { Spark.count }.by(1)
+      end
+      
+      it "should add the user to the spark" do
+        post :create, :spark => @attr, :format => 'json', :username => @user.name
+        spark = Spark.last
+        spark.users.should == [@user]
+      end
+      
+      it "should return the spark" do
+        post :create, :spark => @attr, :format => 'json', :username => @user.name
+        spark = Spark.last
+        response.body.should == spark.to_json
+      end
+      
+    end
+    
+    describe "for an existing spark spark" do
+      
+      before(:each) do
+        @spark = Spark.create(@attr)
+        @spark.users << @user
+        
+        @user2 = FactoryGirl.create(:user)
+      end
+      
+      it "is successful" do
+        post :create, :spark => @attr, :format => 'json', :username => @user2.name
+        response.should be_success
+      end
+    
+      it "shouldn't create the spark" do
+        expect {
+          post :create, :spark => @attr, :format => 'json', :username => @user2.name
+        }.not_to change { Spark.count }
+      end
+      
+      it "should add the user to the spark" do
+        post :create, :spark => @attr, :format => 'json', :username => @user2.name
+        @spark.users.should == [@user, @user2]
+      end
+      
+      it "should return the spark" do
+        post :create, :spark => @attr, :format => 'json', :username => @user2.name
+        response.body.should == @spark.to_json
+      end
+      
+    end
+    
+  end
+  
 end

--- a/web/spec/controllers/v1/sparks_controller_spec.rb
+++ b/web/spec/controllers/v1/sparks_controller_spec.rb
@@ -163,11 +163,12 @@ describe V1::SparksController do
     
     it "removes the user from the spark" do
       delete :destroy, :id => @spark, :format => 'json', :username => @user.name
-      @spark.users.should_not include(@user)
+      @spark.users.include?(@user).should_not be_true
     end
     
     it "returns the spark" do
       delete :destroy, :id => @spark, :format => 'json', :username => @user.name
+      @spark = Spark.find_by_id(@spark.id) # used to force @spark to reload its attributes
       response.body.should == @spark.to_json
     end
     

--- a/web/spec/controllers/v1/sparks_controller_spec.rb
+++ b/web/spec/controllers/v1/sparks_controller_spec.rb
@@ -68,7 +68,7 @@ describe V1::SparksController do
         response.should be_success
       end
     
-      it "should create the spark" do
+      it "shouldn't create the spark" do
         expect {
           post :create, :spark => @attr, :format => 'json', :username => @user.name
         }.to change { Spark.count }.by(1)
@@ -88,7 +88,26 @@ describe V1::SparksController do
       
     end
     
-    describe "for an existing spark spark" do
+    describe "for a new invalid spark" do
+      
+      before(:each) do
+        @attr[:content_type] = ""
+      end
+      
+      it "isn't successful" do
+        post :create, :spark => @attr, :format => 'json', :username => @user.name
+        response.should_not be_success
+      end
+    
+      it "shouldn't create the spark" do
+        expect {
+          post :create, :spark => @attr, :format => 'json', :username => @user.name
+        }.not_to change { Spark.count }
+      end
+      
+    end
+    
+    describe "for an existing spark" do
       
       before(:each) do
         @spark = Spark.create(@attr)

--- a/web/spec/controllers/v1/sparks_controller_spec.rb
+++ b/web/spec/controllers/v1/sparks_controller_spec.rb
@@ -141,4 +141,36 @@ describe V1::SparksController do
     
   end
   
+  describe "DELETE 'destroy'" do
+    
+    before(:each) do
+      @spark = FactoryGirl.create(:spark)
+      @user = FactoryGirl.create(:user)
+      
+      @spark.users << @user
+    end
+    
+    it "is successful" do
+      delete :destroy, :id => @spark, :format => 'json', :username => @user.name
+      response.should be_success
+    end
+    
+    it "doesn't destroy the spark" do
+      expect {
+        delete :destroy, :id => @spark, :format => 'json', :username => @user.name
+      }.not_to change { Spark.count }
+    end
+    
+    it "removes the user from the spark" do
+      delete :destroy, :id => @spark, :format => 'json', :username => @user.name
+      @spark.users.should_not include(@user)
+    end
+    
+    it "returns the spark" do
+      delete :destroy, :id => @spark, :format => 'json', :username => @user.name
+      response.body.should == @spark.to_json
+    end
+    
+  end
+  
 end

--- a/web/spec/models/spark_spec.rb
+++ b/web/spec/models/spark_spec.rb
@@ -19,7 +19,7 @@ describe Spark do
     @attr = {
       :spark_type   => "I",
       :content_type => "L",
-      :content      => "http://google.com/",
+      :content      => "http://google.com/"
     }
   end
   

--- a/web/spec/routing/sparks_routing_spec.rb
+++ b/web/spec/routing/sparks_routing_spec.rb
@@ -27,15 +27,6 @@ describe "routes for Sparks" do
     )
   end
   
-  it "routes put /api/v1/sparks/:id.json to Sparks controller" do
-    { :put => "/api/v1/sparks/1.json" }.should route_to(
-      :controller => "v1/sparks",
-      :action => "update",
-      :id => "1",
-      :format => "json"
-    )
-  end
-  
   it "routes delete /api/v1/sparks/:id.json to Sparks controller" do
     { :delete => "/api/v1/sparks/1.json" }.should route_to(
       :controller => "v1/sparks",


### PR DESCRIPTION
Added handling of a user attempting to create a spark which already exists, by simply adding the user attempting to do so to the spark's list of users. This occurs automatically after making a POST request to `/api/v1/sparks.json` with attributes that correspond to an existing spark.

The Android side can tell when this occurs, because the HTTP status of the response will be 200 (meaning "ok"), rather than the 202 ("created"), than normally occurs when creating a new spark.

Also added more tests for this new feature, and for the Sparks Controller in general.
