### PR TITLE
User-Idea relationships, API token authentication, refactoring

### DIFF
--- a/web/app/controllers/application_controller.rb
+++ b/web/app/controllers/application_controller.rb
@@ -1,3 +1,23 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
+  
+  before_filter :verify_security_token
+  
+  private
+    
+    def verify_security_token
+
+    end
+    
+    def authenticate
+      @user = User.find_by_name(params[:username])
+      
+      if(!@user)
+        hash = { :error => "Invalid username." }
+        respond_to do |format|
+          format.json { render :json => hash, :status => :unauthorized }
+        end
+      end
+    end
+    
 end

--- a/web/app/controllers/application_controller.rb
+++ b/web/app/controllers/application_controller.rb
@@ -6,7 +6,9 @@ class ApplicationController < ActionController::Base
   private
     
     def verify_security_token
-
+      # unless Digest::SHA1.hexdigest(params[:token]) == "639bab0291d34056baee0ebd1664f516ccb67efd" # Digest::SHA1.hexdigest("0577a090fea6e735f471d349b14456ea34924b00")
+      #   head :unauthorized
+      # end
     end
     
     def authenticate

--- a/web/app/controllers/v1/comments_controller.rb
+++ b/web/app/controllers/v1/comments_controller.rb
@@ -1,5 +1,7 @@
 class V1::CommentsController < ApplicationController
-  # GET /comments
+  
+  before_filter :authenticate, :only => [:create, :update, :destroy]
+  
   # GET /comments.json
   def index
     @comments = Comment.all
@@ -9,8 +11,7 @@ class V1::CommentsController < ApplicationController
       format.json { render :json => @comments }
     end
   end
-
-  # GET /comments/1
+  
   # GET /comments/1.json
   def show
     @comment = Comment.find(params[:id])
@@ -21,32 +22,23 @@ class V1::CommentsController < ApplicationController
     end
   end
   
-  # POST /comments
   # POST /comments.json
   def create
     @comment = Comment.new(params[:comment])
 
     respond_to do |format|
-      user = User.find_by_name(params[:username])
-      
-      if user
-        if @comment.save
-          @comment.user = user
-          
-          format.html { redirect_to @comment, :notice => 'Comment was successfully created.' }
-          format.json { render :json => @comment, :status => :created, :location => ["v1", @comment] }
-        else
-          format.html { render :action => "new" }
-          format.json { render :json => @comment.errors, :status => :unprocessable_entity }
-        end
+      if @comment.save
+        @comment.user = @user
+        
+        format.html { redirect_to @comment, :notice => 'Comment was successfully created.' }
+        format.json { render :json => @comment, :status => :created, :location => ["v1", @comment] }
       else
         format.html { render :action => "new" }
-        format.json { render :json => @comment.errors, :status => :unauthorized }
+        format.json { render :json => @comment.errors, :status => :unprocessable_entity }
       end
     end
   end
-
-  # PUT /comments/1
+  
   # PUT /comments/1.json
   def update
     @comment = Comment.find(params[:id])
@@ -61,8 +53,7 @@ class V1::CommentsController < ApplicationController
       end
     end
   end
-
-  # DELETE /comments/1
+  
   # DELETE /comments/1.json
   def destroy
     @comment = Comment.find(params[:id])

--- a/web/app/controllers/v1/ideas_controller.rb
+++ b/web/app/controllers/v1/ideas_controller.rb
@@ -83,8 +83,9 @@ class V1::IdeasController < ApplicationController
   def destroy
     @idea = Idea.find(params[:id])
     
-    if @idea && @idea.users.include?(@user)
-      @idea.users.delete(@user)
+    if @idea && (@idea.user == @user)
+      @idea.user = nil
+      @idea.save
       
       respond_to do |format|
         format.json { render :json => @idea, :status => :ok }

--- a/web/app/controllers/v1/ideas_controller.rb
+++ b/web/app/controllers/v1/ideas_controller.rb
@@ -1,5 +1,8 @@
 class V1::IdeasController < ApplicationController
-  # GET /ideas
+  
+  respond_to :json
+  before_filter :authenticate, :only => [:create, :destroy]
+  
   # GET /ideas.json
   def index
     if params[:limit]
@@ -7,93 +10,81 @@ class V1::IdeasController < ApplicationController
     else
       @ideas = Idea.order("id DESC")
     end
-
-    respond_to do |format|
-      format.html # index.html.erb
-      format.json { render :json => @ideas }
-    end
+    
+    respond_with @ideas
   end
-
-  # GET /ideas/1
+  
   # GET /ideas/1.json
   def show
     @idea = Idea.find(params[:id])
-
-    respond_to do |format|
-      format.html # show.html.erb
-      format.json { render :json => @idea }
-    end
+    
+    respond_with @idea
   end
   
-  # POST /ideas
   # POST /ideas.json
   def create
     @idea = Idea.new(params[:idea])
     
-    respond_to do |format|
-      user = User.find_by_name(params[:username])
-      
-      if user
-        if params[:sparks]
-          spark_ids = params[:sparks].split(",")
-          sparks = []
-        
-          sparks_exist = false
+    if params[:sparks]
+      spark_ids = params[:sparks].split(",")
+      sparks = []
+    
+      sparks_exist = false
 
-          spark_ids.each do |spark_id|
-            if s = Spark.find_by_id(spark_id.to_i)
-              sparks_exist = true
-              sparks << s
-            end
-          end
-        
-          if sparks_exist && @idea.save
-            if(params[:tags])
-              tags = params[:tags].split(",")
-            
-              tags.each do |tag_name|
-                tag = Tag.where(:tag_text => tag_name).first
-              
-                unless(tag)
-                  tag = Tag.new(:tag_text => tag_name)
-                  tag.save
-                end
-              
-                tag.ideas << @idea
-              end
-            end
-          
-            sparks.each do |spark|
-              @idea.sparks << spark
-            end
-          
-            user.ideas << @idea
-            
-            format.html { redirect_to @idea, :notice => 'Idea was successfully created.' }
-            format.json { render :json => @idea, :status => :created, :location => ["v1", @idea] }
-          else # Either no valid sparks were passed or the idea didn't save
-            format.html { render :action => "new" }
-            format.json { render :json => @idea.errors, :status => :unprocessable_entity }
-          end
-        else # No sparks passed in
-          format.html { render :action => "new" }
-          format.json { render :json => @idea.errors, :status => :unprocessable_entity }
+      spark_ids.each do |spark_id|
+        if s = Spark.find_by_id(spark_id.to_i)
+          sparks_exist = true
+          sparks << s
         end
-      else # User doesn't exist or wasn't passed in
-        format.html { render :action => "new" }
-        format.json { render :json => @idea.errors, :status => :unauthorized }
+      end
+      
+      if sparks_exist
+        if @idea.save
+          if(params[:tags])
+            tags = params[:tags].split(",")
+
+            tags.each do |tag_name|
+              tag = Tag.where(:tag_text => tag_name).first
+
+              unless(tag)
+                tag = Tag.new(:tag_text => tag_name)
+                tag.save
+              end
+
+              tag.ideas << @idea
+            end
+          end
+
+          sparks.each do |spark|
+            @idea.sparks << spark
+          end
+
+          @user.ideas << @idea
+        end
+
+        respond_with @idea, :location => ["v1", @idea]
+      else
+        hash = { :error => "Invalid sparks." }
+
+        respond_to do |format|
+          format.json { render :json => hash, :status => :unprocessable_entity }
+        end
+      end
+    else
+      hash = { :error => "No sparks." }
+      
+      respond_to do |format|
+        format.json { render :json => hash, :status => :unprocessable_entity }
       end
     end
   end
-
-  # DELETE /ideas/1
+  
   # DELETE /ideas/1.json
   def destroy
     @idea = Idea.find(params[:id])
-    user = User.find_by_name(params[:username])
     
-    if @idea && user && @idea.users.include?(user)
-      @idea.users.delete(user)
+    if @idea && @idea.users.include?(@user)
+      @idea.users.delete(@user)
       
       respond_to do |format|
         format.html { redirect_to ideas_url }

--- a/web/app/controllers/v1/ideas_controller.rb
+++ b/web/app/controllers/v1/ideas_controller.rb
@@ -87,7 +87,6 @@ class V1::IdeasController < ApplicationController
       @idea.users.delete(@user)
       
       respond_to do |format|
-        format.html { redirect_to ideas_url }
         format.json { render :json => @idea, :status => :ok }
       end
     end

--- a/web/app/controllers/v1/jawns_controller.rb
+++ b/web/app/controllers/v1/jawns_controller.rb
@@ -1,6 +1,7 @@
 class V1::JawnsController < ApplicationController
   
-  # GET /jawns
+  respond_to :json
+  
   # GET /jawns.json
   def index
     if params[:filter] == "sparks"
@@ -29,9 +30,7 @@ class V1::JawnsController < ApplicationController
       end
     end
     
-    respond_to do |format|
-      format.json { render :json => @jawns }
-    end
+    respond_with @jawns
   end
   
 end

--- a/web/app/controllers/v1/sparks_controller.rb
+++ b/web/app/controllers/v1/sparks_controller.rb
@@ -55,6 +55,8 @@ class V1::SparksController < ApplicationController
           format.html { redirect_to @spark, :notice => 'Spark was successfully created.' }
           format.json { render :json => @spark, :status => :created, :location => ["v1", @spark] }
         elsif @spark.duplicate?
+          # TODO: Handle the different spark_types provided by multiple users
+          
           @spark = Spark.find_by_content_hash(@spark.content_hash)
           
           unless(@spark.users.include?(user))

--- a/web/app/controllers/v1/sparks_controller.rb
+++ b/web/app/controllers/v1/sparks_controller.rb
@@ -1,5 +1,8 @@
 class V1::SparksController < ApplicationController
-  # GET /sparks
+  
+  respond_to :json
+  before_filter :authenticate, :only => [:create, :destroy]
+  
   # GET /sparks.json
   def index
     if params[:limit]
@@ -8,87 +11,61 @@ class V1::SparksController < ApplicationController
       @sparks = Spark.order("id DESC")
     end
     
-    respond_to do |format|
-      format.html # index.html.erb
-      format.json { render :json => @sparks }
-    end
+    respond_with @sparks
   end
-
-  # GET /sparks/1
+  
   # GET /sparks/1.json
   def show
     @spark = Spark.find(params[:id])
-
-    respond_to do |format|
-      format.html # show.html.erb
-      format.json { render :json => @spark }
-    end
+    
+    respond_with @spark
   end
   
-  # POST /sparks
   # POST /sparks.json
   def create
     @spark = Spark.new(params[:spark])
-    
-    respond_to do |format|
-      user = User.find_by_name(params[:username])
-      
-      if user
-        if @spark.save
-          if(params[:tags])
-            tags = params[:tags].split(",")
-            
-            tags.each do |tag_name|
-              tag = Tag.where(:tag_text => tag_name).first
-              
-              unless(tag)
-                tag = Tag.new(:tag_text => tag_name)
-                tag.save
-              end
-              
-              tag.sparks << @idea
-            end
-          end
-          
-          user.sparks << @spark
         
-          format.html { redirect_to @spark, :notice => 'Spark was successfully created.' }
-          format.json { render :json => @spark, :status => :created, :location => ["v1", @spark] }
-        elsif @spark.duplicate?
-          # TODO: Handle the different spark_types provided by multiple users
+    if @spark.save
+      if(params[:tags])
+        tags = params[:tags].split(",")
+        
+        tags.each do |tag_name|
+          tag = Tag.where(:tag_text => tag_name).first
           
-          @spark = Spark.find_by_content_hash(@spark.content_hash)
-          
-          unless(@spark.users.include?(user))
-            @spark.users << user
+          unless(tag)
+            tag = Tag.new(:tag_text => tag_name)
+            tag.save
           end
           
-          format.html { render :action => "new" }
-          format.json { render :json => @spark, :status => :ok }
-        else
-          format.html { render :action => "new" }
-          format.json { render :json => @spark.errors, :status => :unprocessable_entity }
+          tag.sparks << @idea
         end
-      else
-        format.html { render :action => "new" }
-        format.json { render :json => @spark.errors, :status => :unauthorized }
+      end
+      
+      @user.sparks << @spark
+    elsif @spark.duplicate?
+      # TODO: Handle the different spark_types provided by multiple users
+      
+      @spark = Spark.find_by_content_hash(@spark.content_hash)
+      
+      unless(@spark.users.include?(@user))
+        @spark.users << @user
       end
     end
+    
+    respond_with @spark, :location => ["v1", @spark]
   end
-
-  # DELETE /sparks/1
+  
   # DELETE /sparks/1.json
   def destroy
     @spark = Spark.find(params[:id])
-    user = User.find_by_name(params[:username])
     
-    if @spark && user && @spark.users.include?(user)
-      @spark.users.delete(user)
+    if @spark && @spark.users.include?(@user)
+      @spark.users.delete(@user)
       
       respond_to do |format|
-        format.html { redirect_to sparks_url }
         format.json { render :json => @spark, :status => :ok }
       end
     end
   end
+  
 end

--- a/web/app/controllers/v1/users_controller.rb
+++ b/web/app/controllers/v1/users_controller.rb
@@ -1,13 +1,12 @@
 class V1::UsersController < ApplicationController
-  # GET /users
+  
+  respond_to :json
+  
   # GET /users.json
   def index
     @users = User.all
 
-    respond_to do |format|
-      format.html # index.html.erb
-      format.json { render :json => @users }
-    end
+    respond_with @users
   end
 
   # GET /users/1
@@ -15,42 +14,25 @@ class V1::UsersController < ApplicationController
   def show
     @user = User.find_by_name(params[:id])
 
-    respond_to do |format|
-      format.html # show.html.erb
-      format.json { render :json => @user }
-    end
+    respond_with @user
   end
 
   # POST /users
   # POST /users.json
   def create
     @user = User.new(params[:user])
+    @user.save
     
-    respond_to do |format|
-      if @user.save
-        format.html { redirect_to @user, :notice => 'User was successfully created.' }
-        format.json { render :json => @user, :status => :created, :location => ["v1", @user] }
-      else
-        format.html { render :action => "new" }
-        format.json { render :json => @user.errors, :status => :unprocessable_entity }
-      end
-    end
+    respond_with @user, :location => ["v1", @user]
   end
 
   # PUT /users/1
   # PUT /users/1.json
   def update
     @user = User.find_by_name(params[:id])
-
-    respond_to do |format|
-      if @user.update_attributes(params[:user])
-        format.html { redirect_to @user, :notice => 'User was successfully updated.' }
-        format.json { head :no_content }
-      else
-        format.html { render :action => "edit" }
-        format.json { render :json => @user.errors, :status => :unprocessable_entity }
-      end
-    end
+    @user.update_attributes(params[:user])
+    
+    respond_with @user, :stautus => :ok
   end
 
   # DELETE /users/1
@@ -58,10 +40,7 @@ class V1::UsersController < ApplicationController
   def destroy
     @user = User.find_by_name(params[:id])
     @user.destroy
-
-    respond_to do |format|
-      format.html { redirect_to users_url }
-      format.json { head :no_content }
-    end
+    
+    head :no_content
   end
 end

--- a/web/app/controllers/v1/users_controller.rb
+++ b/web/app/controllers/v1/users_controller.rb
@@ -13,7 +13,7 @@ class V1::UsersController < ApplicationController
   # GET /users/1
   # GET /users/1.json
   def show
-    @user = User.find(params[:id])
+    @user = User.find_by_name(params[:id])
 
     respond_to do |format|
       format.html # show.html.erb
@@ -40,7 +40,7 @@ class V1::UsersController < ApplicationController
   # PUT /users/1
   # PUT /users/1.json
   def update
-    @user = User.find(params[:id])
+    @user = User.find_by_name(params[:id])
 
     respond_to do |format|
       if @user.update_attributes(params[:user])
@@ -56,7 +56,7 @@ class V1::UsersController < ApplicationController
   # DELETE /users/1
   # DELETE /users/1.json
   def destroy
-    @user = User.find(params[:id])
+    @user = User.find_by_name(params[:id])
     @user.destroy
 
     respond_to do |format|

--- a/web/app/models/idea.rb
+++ b/web/app/models/idea.rb
@@ -6,19 +6,20 @@
 #  description :text
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  user_id     :integer
 #
 
 class Idea < ActiveRecord::Base
   attr_accessible :description
   
+  belongs_to :user
   has_and_belongs_to_many :sparks
-  has_and_belongs_to_many :users
   has_many :comments, :as => :commentable, :dependent => :destroy
   has_many :tags, :through => :tag_linkers
   has_many :tag_linkers, :as => :tagable
   
   def as_json(options={})
-    json = super(:include => [:sparks, :tags, :comments, :users])
+    json = super(:include => [:sparks, :tags, :comments, :user])
     json[:jawn_type] = "idea"
     return json
   end

--- a/web/app/models/spark.rb
+++ b/web/app/models/spark.rb
@@ -42,7 +42,9 @@ class Spark < ActiveRecord::Base
   private
   
     def hash_content
-      self.content_hash = Digest::SHA1.hexdigest(self.content_type+"-"+self.content)
+      if (self.content && self.content_type)
+        self.content_hash = Digest::SHA1.hexdigest(self.content_type+"-"+self.content)
+      end
     end
     
 end

--- a/web/app/models/user.rb
+++ b/web/app/models/user.rb
@@ -11,6 +11,10 @@
 #
 
 class User < ActiveRecord::Base
+  def to_param
+    name
+  end
+  
   attr_accessible :email, :name, :password
   
   has_secure_password

--- a/web/app/models/user.rb
+++ b/web/app/models/user.rb
@@ -19,8 +19,8 @@ class User < ActiveRecord::Base
   
   has_secure_password
   
-  has_and_belongs_to_many :ideas
   has_and_belongs_to_many :sparks
+  has_many :ideas
   has_many :comments
   
   validates :email, :presence => true, :format => { :with => /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/, :message => "Must be a valid email address." }, :uniqueness => { :case_sensitive => false }

--- a/web/db/migrate/20130618232537_change_ideas_and_users_relationship.rb
+++ b/web/db/migrate/20130618232537_change_ideas_and_users_relationship.rb
@@ -1,0 +1,33 @@
+class ChangeIdeasAndUsersRelationship < ActiveRecord::Migration
+  def up
+    add_column :ideas, :user_id, :integer
+    
+    Idea.all.each do |idea|
+      user = idea.users.first
+      
+      if user
+        idea.user = user
+        idea.save
+      end
+    end
+    
+    drop_table :ideas_users
+  end
+
+  def down
+    create_table :ideas_users, :id => false do |t|
+      t.integer :idea_id
+      t.integer :user_id
+    end
+    
+    Idea.all.each do |idea|
+      user = idea.user
+      
+      if user
+        idea.users << user
+      end
+    end
+    
+    remove_columns :ideas, :user_id
+  end
+end

--- a/web/db/schema.rb
+++ b/web/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130531012743) do
+ActiveRecord::Schema.define(:version => 20130618232537) do
 
   create_table "comments", :force => true do |t|
     t.text     "comment_text"
@@ -26,16 +26,12 @@ ActiveRecord::Schema.define(:version => 20130531012743) do
     t.text     "description"
     t.datetime "created_at",  :null => false
     t.datetime "updated_at",  :null => false
+    t.integer  "user_id"
   end
 
   create_table "ideas_sparks", :id => false, :force => true do |t|
     t.integer "idea_id"
     t.integer "spark_id"
-  end
-
-  create_table "ideas_users", :id => false, :force => true do |t|
-    t.integer "idea_id"
-    t.integer "user_id"
   end
 
   create_table "sparks", :force => true do |t|

--- a/web/spec/controllers/v1/comments_controller_spec.rb
+++ b/web/spec/controllers/v1/comments_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
 describe V1::CommentsController do
-
+  
+  
+  
 end

--- a/web/spec/controllers/v1/ideas_controller_spec.rb
+++ b/web/spec/controllers/v1/ideas_controller_spec.rb
@@ -15,17 +15,17 @@ describe V1::IdeasController do
     end
     
     it "is successful" do
-      get :index, :format => 'json'
+      get :index, :format => 'json', :token => @auth_token
       response.should be_success
     end
     
     it "returns the correct ideas" do
-      get :index, :format => 'json'
+      get :index, :format => 'json', :token => @auth_token
       response.body.should == @ideas.to_json
     end
     
     it "limits the ideas correctly" do
-      get :index, :format => 'json', :limit => 10
+      get :index, :format => 'json', :limit => 10, :token => @auth_token
       response.body.should == @ideas.take(10).to_json
     end
     
@@ -38,12 +38,12 @@ describe V1::IdeasController do
     end
     
     it "is successful" do
-      get :show, :id => @idea, :format => 'json'
+      get :show, :id => @idea, :format => 'json', :token => @auth_token
       response.should be_success
     end
     
     it "returns the correct idea" do
-      get :show, :id => @idea, :format => 'json'
+      get :show, :id => @idea, :format => 'json', :token => @auth_token
       response.body.should == @idea.to_json
     end
     
@@ -67,30 +67,30 @@ describe V1::IdeasController do
     describe "for a new valid idea" do
       
       it "is successful" do
-        post :create, :idea => @attr, :format => 'json', :username => @user.name, :sparks => @sparks
+        post :create, :idea => @attr, :format => 'json', :username => @user.name, :sparks => @sparks, :token => @auth_token
         response.should be_success
       end
     
       it "should create the idea" do
         expect {
-          post :create, :idea => @attr, :format => 'json', :username => @user.name, :sparks => @sparks
+          post :create, :idea => @attr, :format => 'json', :username => @user.name, :sparks => @sparks, :token => @auth_token
         }.to change { Idea.count }.by(1)
       end
       
       it "should add the user to the idea" do
-        post :create, :idea => @attr, :format => 'json', :username => @user.name, :sparks => @sparks
+        post :create, :idea => @attr, :format => 'json', :username => @user.name, :sparks => @sparks, :token => @auth_token
         @idea = Idea.last
         @idea.users.should == [@user]
       end
       
       it "should add the sparks to the idea" do
-        post :create, :idea => @attr, :format => 'json', :username => @user.name, :sparks => @sparks
+        post :create, :idea => @attr, :format => 'json', :username => @user.name, :sparks => @sparks, :token => @auth_token
         @idea = Idea.last
         @idea.sparks.should == [@s1, @s2]
       end
       
       it "should return the idea" do
-        post :create, :idea => @attr, :format => 'json', :username => @user.name, :sparks => @sparks
+        post :create, :idea => @attr, :format => 'json', :username => @user.name, :sparks => @sparks, :token => @auth_token
         @idea = Idea.last
         response.body.should == @idea.to_json
       end
@@ -100,13 +100,13 @@ describe V1::IdeasController do
     describe "for an idea without sparks" do
       
       it "isn't successful" do
-        post :create, :idea => @attr, :format => 'json', :username => @user.name
+        post :create, :idea => @attr, :format => 'json', :username => @user.name, :token => @auth_token
         response.should_not be_success
       end
     
       it "shouldn't create the idea" do
         expect {
-          post :create, :idea => @attr, :format => 'json', :username => @user.name
+          post :create, :idea => @attr, :format => 'json', :username => @user.name, :token => @auth_token
         }.not_to change { Idea.count }
       end
       
@@ -115,13 +115,13 @@ describe V1::IdeasController do
     describe "for an idea with invalid sparks" do
       
       it "isn't successful" do
-        post :create, :idea => @attr, :format => 'json', :username => @user.name, :sparks => "100,150"
+        post :create, :idea => @attr, :format => 'json', :username => @user.name, :sparks => "100,150", :token => @auth_token
         response.should_not be_success
       end
     
       it "shouldn't create the idea" do
         expect {
-          post :create, :idea => @attr, :format => 'json', :username => @user.name, :sparks => "100,150"
+          post :create, :idea => @attr, :format => 'json', :username => @user.name, :sparks => "100,150", :token => @auth_token
         }.not_to change { Idea.count }
       end
       
@@ -146,23 +146,23 @@ describe V1::IdeasController do
     end
     
     it "is successful" do
-      delete :destroy, :id => @idea, :format => 'json', :username => @user.name
+      delete :destroy, :id => @idea, :format => 'json', :username => @user.name, :token => @auth_token
       response.should be_success
     end
     
     it "doesn't destroy the idea" do
       expect {
-        delete :destroy, :id => @idea, :format => 'json', :username => @user.name
+        delete :destroy, :id => @idea, :format => 'json', :username => @user.name, :token => @auth_token
       }.not_to change { Idea.count }
     end
     
     it "removes the user from the idea" do
-      delete :destroy, :id => @idea, :format => 'json', :username => @user.name
+      delete :destroy, :id => @idea, :format => 'json', :username => @user.name, :token => @auth_token
       @idea.users.include?(@user).should_not be_true
     end
     
     it "returns the idea" do
-      delete :destroy, :id => @idea, :format => 'json', :username => @user.name
+      delete :destroy, :id => @idea, :format => 'json', :username => @user.name, :token => @auth_token
       @idea = Idea.find_by_id(@idea.id) # used to force @spark to reload its attributes
       response.body.should == @idea.to_json
     end

--- a/web/spec/controllers/v1/ideas_controller_spec.rb
+++ b/web/spec/controllers/v1/ideas_controller_spec.rb
@@ -80,7 +80,7 @@ describe V1::IdeasController do
       it "should add the user to the idea" do
         post :create, :idea => @attr, :format => 'json', :username => @user.name, :sparks => @sparks, :token => @auth_token
         @idea = Idea.last
-        @idea.users.should == [@user]
+        @idea.user.should == @user
       end
       
       it "should add the sparks to the idea" do
@@ -142,7 +142,8 @@ describe V1::IdeasController do
       @idea.sparks << @s1
       @idea.sparks << @s2
       
-      @idea.users << @user
+      @idea.user = @user
+      @idea.save
     end
     
     it "is successful" do
@@ -158,12 +159,13 @@ describe V1::IdeasController do
     
     it "removes the user from the idea" do
       delete :destroy, :id => @idea, :format => 'json', :username => @user.name, :token => @auth_token
-      @idea.users.include?(@user).should_not be_true
+      @idea.reload
+      @idea.user.should be_nil
     end
     
     it "returns the idea" do
       delete :destroy, :id => @idea, :format => 'json', :username => @user.name, :token => @auth_token
-      @idea = Idea.find_by_id(@idea.id) # used to force @spark to reload its attributes
+      @idea.reload
       response.body.should == @idea.to_json
     end
     

--- a/web/spec/controllers/v1/jawns_controller_spec.rb
+++ b/web/spec/controllers/v1/jawns_controller_spec.rb
@@ -27,29 +27,29 @@ describe V1::JawnsController do
     end
     
     it "is successful" do
-      get :index, :format => 'json'
+      get :index, :format => 'json', :token => @auth_token
       response.should be_success
     end
     
     it "returns the correct jawns" do
-      get :index, :format => 'json'
+      get :index, :format => 'json', :token => @auth_token
       response.body.should == @jawns.to_json
     end
     
     it "limits the jawns correctly" do
-      get :index, :format => 'json', :limit => 10
+      get :index, :format => 'json', :limit => 10, :token => @auth_token
       response.body.should == @jawns.take(10).to_json
     end
     
     describe "idea filtering" do
       
       it "filters ideas correctly" do
-        get :index, :format => 'json', :filter => "ideas"
+        get :index, :format => 'json', :filter => "ideas", :token => @auth_token
         response.body.should == @ideas.to_json
       end
       
       it "filters ideas with a limit correctly" do
-        get :index, :format => 'json', :filter => "ideas", :limit => 3
+        get :index, :format => 'json', :filter => "ideas", :limit => 3, :token => @auth_token
         response.body.should == @ideas.take(3).to_json
       end
       
@@ -58,12 +58,12 @@ describe V1::JawnsController do
     describe "spark filtering" do
       
       it "filters sparks correctly" do
-        get :index, :format => 'json', :filter => "sparks"
+        get :index, :format => 'json', :filter => "sparks", :token => @auth_token
         response.body.should == @sparks.to_json
       end
       
       it "filters sparks with a limit correctly" do
-        get :index, :format => 'json', :filter => "sparks", :limit => 3
+        get :index, :format => 'json', :filter => "sparks", :limit => 3, :token => @auth_token
         response.body.should == @sparks.take(3).to_json
       end
       

--- a/web/spec/controllers/v1/sparks_controller_spec.rb
+++ b/web/spec/controllers/v1/sparks_controller_spec.rb
@@ -15,17 +15,17 @@ describe V1::SparksController do
     end
     
     it "is successful" do
-      get :index, :format => 'json'
+      get :index, :format => 'json', :token => @auth_token
       response.should be_success
     end
     
     it "returns the correct sparks" do
-      get :index, :format => 'json'
+      get :index, :format => 'json', :token => @auth_token
       response.body.should == @sparks.to_json
     end
     
     it "limits the sparks correctly" do
-      get :index, :format => 'json', :limit => 10
+      get :index, :format => 'json', :limit => 10, :token => @auth_token
       response.body.should == @sparks.take(10).to_json
     end
     
@@ -38,12 +38,12 @@ describe V1::SparksController do
     end
     
     it "is successful" do
-      get :show, :id => @spark, :format => 'json'
+      get :show, :id => @spark, :format => 'json', :token => @auth_token
       response.should be_success
     end
     
     it "returns the correct spark" do
-      get :show, :id => @spark, :format => 'json'
+      get :show, :id => @spark, :format => 'json', :token => @auth_token
       response.body.should == @spark.to_json
     end
     
@@ -64,24 +64,24 @@ describe V1::SparksController do
     describe "for a new valid spark" do
       
       it "is successful" do
-        post :create, :spark => @attr, :format => 'json', :username => @user.name
+        post :create, :spark => @attr, :format => 'json', :username => @user.name, :token => @auth_token
         response.should be_success
       end
     
       it "should create the spark" do
         expect {
-          post :create, :spark => @attr, :format => 'json', :username => @user.name
+          post :create, :spark => @attr, :format => 'json', :username => @user.name, :token => @auth_token
         }.to change { Spark.count }.by(1)
       end
       
       it "should add the user to the spark" do
-        post :create, :spark => @attr, :format => 'json', :username => @user.name
+        post :create, :spark => @attr, :format => 'json', :username => @user.name, :token => @auth_token
         @spark = Spark.last
         @spark.users.should == [@user]
       end
       
       it "should return the spark" do
-        post :create, :spark => @attr, :format => 'json', :username => @user.name
+        post :create, :spark => @attr, :format => 'json', :username => @user.name, :token => @auth_token
         @spark = Spark.last
         response.body.should == @spark.to_json
       end
@@ -95,13 +95,13 @@ describe V1::SparksController do
       end
       
       it "isn't successful" do
-        post :create, :spark => @attr, :format => 'json', :username => @user.name
+        post :create, :spark => @attr, :format => 'json', :username => @user.name, :token => @auth_token
         response.should_not be_success
       end
     
       it "shouldn't create the spark" do
         expect {
-          post :create, :spark => @attr, :format => 'json', :username => @user.name
+          post :create, :spark => @attr, :format => 'json', :username => @user.name, :token => @auth_token
         }.not_to change { Spark.count }
       end
       
@@ -117,23 +117,23 @@ describe V1::SparksController do
       end
       
       it "is successful" do
-        post :create, :spark => @attr, :format => 'json', :username => @user2.name
+        post :create, :spark => @attr, :format => 'json', :username => @user2.name, :token => @auth_token
         response.should be_success
       end
     
       it "shouldn't create the spark" do
         expect {
-          post :create, :spark => @attr, :format => 'json', :username => @user2.name
+          post :create, :spark => @attr, :format => 'json', :username => @user2.name, :token => @auth_token
         }.not_to change { Spark.count }
       end
       
       it "should add the user to the spark" do
-        post :create, :spark => @attr, :format => 'json', :username => @user2.name
+        post :create, :spark => @attr, :format => 'json', :username => @user2.name, :token => @auth_token
         @spark.users.should == [@user, @user2]
       end
       
       it "should return the spark" do
-        post :create, :spark => @attr, :format => 'json', :username => @user2.name
+        post :create, :spark => @attr, :format => 'json', :username => @user2.name, :token => @auth_token
         response.body.should == @spark.to_json
       end
       
@@ -151,23 +151,23 @@ describe V1::SparksController do
     end
     
     it "is successful" do
-      delete :destroy, :id => @spark, :format => 'json', :username => @user.name
+      delete :destroy, :id => @spark, :format => 'json', :username => @user.name, :token => @auth_token
       response.should be_success
     end
     
     it "doesn't destroy the spark" do
       expect {
-        delete :destroy, :id => @spark, :format => 'json', :username => @user.name
+        delete :destroy, :id => @spark, :format => 'json', :username => @user.name, :token => @auth_token
       }.not_to change { Spark.count }
     end
     
     it "removes the user from the spark" do
-      delete :destroy, :id => @spark, :format => 'json', :username => @user.name
+      delete :destroy, :id => @spark, :format => 'json', :username => @user.name, :token => @auth_token
       @spark.users.include?(@user).should_not be_true
     end
     
     it "returns the spark" do
-      delete :destroy, :id => @spark, :format => 'json', :username => @user.name
+      delete :destroy, :id => @spark, :format => 'json', :username => @user.name, :token => @auth_token
       @spark = Spark.find_by_id(@spark.id) # used to force @spark to reload its attributes
       response.body.should == @spark.to_json
     end

--- a/web/spec/controllers/v1/sparks_controller_spec.rb
+++ b/web/spec/controllers/v1/sparks_controller_spec.rb
@@ -168,7 +168,7 @@ describe V1::SparksController do
     
     it "returns the spark" do
       delete :destroy, :id => @spark, :format => 'json', :username => @user.name, :token => @auth_token
-      @spark = Spark.find_by_id(@spark.id) # used to force @spark to reload its attributes
+      @spark.reload
       response.body.should == @spark.to_json
     end
     

--- a/web/spec/controllers/v1/tags_controller_spec.rb
+++ b/web/spec/controllers/v1/tags_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
 describe V1::TagsController do
-
+  
+  
+  
 end

--- a/web/spec/controllers/v1/users_controller_spec.rb
+++ b/web/spec/controllers/v1/users_controller_spec.rb
@@ -13,12 +13,12 @@ describe V1::UsersController do
     end
     
     it "is successful" do
-      get :index, :format => 'json'
+      get :index, :format => 'json', :token => @auth_token
       response.should be_success
     end
     
     it "returns the correct users" do
-      get :index, :format => 'json'
+      get :index, :format => 'json', :token => @auth_token
       response.body.should == @users.to_json
     end
     
@@ -31,12 +31,12 @@ describe V1::UsersController do
     end
     
     it "is successful" do
-      get :show, :id => @user, :format => 'json'
+      get :show, :id => @user, :format => 'json', :token => @auth_token
       response.should be_success
     end
     
     it "returns the correct user" do
-      get :show, :id => @user, :format => 'json'
+      get :show, :id => @user, :format => 'json', :token => @auth_token
       response.body.should == @user.to_json
     end
     
@@ -55,18 +55,18 @@ describe V1::UsersController do
     describe "for a new valid user" do
       
       it "is successful" do
-        post :create, :user => @attr, :format => 'json'
+        post :create, :user => @attr, :format => 'json', :token => @auth_token
         response.should be_success
       end
     
       it "should create the user" do
         expect {
-          post :create, :user => @attr, :format => 'json'
+          post :create, :user => @attr, :format => 'json', :token => @auth_token
         }.to change { User.count }.by(1)
       end
       
       it "should return the user" do
-        post :create, :user => @attr, :format => 'json'
+        post :create, :user => @attr, :format => 'json', :token => @auth_token
         response.body.should == User.find_by_name(@attr[:name]).to_json
       end
       
@@ -79,13 +79,13 @@ describe V1::UsersController do
       end
       
       it "isn't successful" do
-        post :create, :user => @attr, :format => 'json'
+        post :create, :user => @attr, :format => 'json', :token => @auth_token
         response.should_not be_success
       end
     
       it "shouldn't create the user" do
         expect {
-          post :create, :user => @attr, :format => 'json'
+          post :create, :user => @attr, :format => 'json', :token => @auth_token
         }.not_to change { User.count }
       end
       
@@ -105,12 +105,12 @@ describe V1::UsersController do
     end
     
     it "is successful" do
-      put :update, :id => @user, :user => @attr, :format => 'json'
+      put :update, :id => @user, :user => @attr, :format => 'json', :token => @auth_token
       response.should be_success
     end
     
     it "updates the user" do
-      put :update, :id => @user, :user => @attr, :format => 'json'
+      put :update, :id => @user, :user => @attr, :format => 'json', :token => @auth_token
       @user = User.find_by_id(@user.id)
       @user.name.should == @attr[:name]
       @user.email.should == @attr[:email]
@@ -125,13 +125,13 @@ describe V1::UsersController do
     end
     
     it "is successful" do
-      delete :destroy, :id => @user, :format => 'json'
+      delete :destroy, :id => @user, :format => 'json', :token => @auth_token
       response.should be_success
     end
     
     it "destroys the user" do
       expect {
-        delete :destroy, :id => @user, :format => 'json'
+        delete :destroy, :id => @user, :format => 'json', :token => @auth_token
       }.to change { User.count }.by(-1)
     end
     

--- a/web/spec/controllers/v1/users_controller_spec.rb
+++ b/web/spec/controllers/v1/users_controller_spec.rb
@@ -111,7 +111,7 @@ describe V1::UsersController do
     
     it "updates the user" do
       put :update, :id => @user, :user => @attr, :format => 'json', :token => @auth_token
-      @user = User.find_by_id(@user.id)
+      @user.reload
       @user.name.should == @attr[:name]
       @user.email.should == @attr[:email]
     end

--- a/web/spec/controllers/v1/users_controller_spec.rb
+++ b/web/spec/controllers/v1/users_controller_spec.rb
@@ -1,5 +1,140 @@
 require 'spec_helper'
 
 describe V1::UsersController do
-
+  
+  describe "GET 'index'" do
+    
+    before(:each) do
+      @users = []
+      
+      20.times do
+        @users << FactoryGirl.create(:user)
+      end
+    end
+    
+    it "is successful" do
+      get :index, :format => 'json'
+      response.should be_success
+    end
+    
+    it "returns the correct users" do
+      get :index, :format => 'json'
+      response.body.should == @users.to_json
+    end
+    
+  end
+  
+  describe "GET 'show'" do
+    
+    before(:each) do
+      @user = FactoryGirl.create(:user)
+    end
+    
+    it "is successful" do
+      get :show, :id => @user, :format => 'json'
+      response.should be_success
+    end
+    
+    it "returns the correct user" do
+      get :show, :id => @user, :format => 'json'
+      response.body.should == @user.to_json
+    end
+    
+  end
+  
+  describe "POST 'create'" do
+    
+    before(:each) do
+      @attr = {
+        :name     => "max",
+        :email    => "max@luzuriaga.com",
+        :password => "password"
+      }
+    end
+    
+    describe "for a new valid user" do
+      
+      it "is successful" do
+        post :create, :user => @attr, :format => 'json'
+        response.should be_success
+      end
+    
+      it "should create the user" do
+        expect {
+          post :create, :user => @attr, :format => 'json'
+        }.to change { User.count }.by(1)
+      end
+      
+      it "should return the user" do
+        post :create, :user => @attr, :format => 'json'
+        response.body.should == User.find_by_name(@attr[:name]).to_json
+      end
+      
+    end
+    
+    describe "for a new invalid user" do
+      
+      before(:each) do
+        @attr[:name] = ""
+      end
+      
+      it "isn't successful" do
+        post :create, :user => @attr, :format => 'json'
+        response.should_not be_success
+      end
+    
+      it "shouldn't create the user" do
+        expect {
+          post :create, :user => @attr, :format => 'json'
+        }.not_to change { User.count }
+      end
+      
+    end
+    
+  end
+  
+  describe "PUT 'update'" do
+    
+    before(:each) do
+      @user = FactoryGirl.create(:user)
+      
+      @attr = {
+        :name     => "max",
+        :email    => "max@luzuriaga.com"
+      }
+    end
+    
+    it "is successful" do
+      put :update, :id => @user, :user => @attr, :format => 'json'
+      response.should be_success
+    end
+    
+    it "updates the user" do
+      put :update, :id => @user, :user => @attr, :format => 'json'
+      @user = User.find_by_id(@user.id)
+      @user.name.should == @attr[:name]
+      @user.email.should == @attr[:email]
+    end
+    
+  end
+  
+  describe "DELETE 'destroy'" do
+    
+    before(:each) do
+      @user = FactoryGirl.create(:user)
+    end
+    
+    it "is successful" do
+      delete :destroy, :id => @user, :format => 'json'
+      response.should be_success
+    end
+    
+    it "destroys the user" do
+      expect {
+        delete :destroy, :id => @user, :format => 'json'
+      }.to change { User.count }.by(-1)
+    end
+    
+  end
+  
 end

--- a/web/spec/models/idea_spec.rb
+++ b/web/spec/models/idea_spec.rb
@@ -6,6 +6,7 @@
 #  description :text
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  user_id     :integer
 #
 
 require 'spec_helper'
@@ -56,26 +57,22 @@ describe Idea do
     before(:each) do
       @idea = Idea.create(@attr)
       
-      @u1 = FactoryGirl.create(:user)
-      @u2 = FactoryGirl.create(:user)
-      
-      @u1.ideas << @idea
-      @u2.ideas << @idea
+      @user = FactoryGirl.create(:user)
+            
+      @user.ideas << @idea
     end
     
-    it "has a users attribute" do
-      @idea.should respond_to(:users)
+    it "has a user attribute" do
+      @idea.should respond_to(:user)
     end
     
-    it "has the right users" do
-      @idea.users.should == [@u1, @u2]
+    it "has the right user" do
+      @idea.user.should == @user
     end
     
     it "doesn't destroy associated users" do
       @idea.destroy
-      [@u1, @u2].each do |u|
-        User.find_by_id(u.id).should_not be_nil
-      end
+      User.find_by_id(@user.id).should_not be_nil
     end
     
   end

--- a/web/spec/models/user_spec.rb
+++ b/web/spec/models/user_spec.rb
@@ -145,8 +145,11 @@ describe User do
       @i1 = FactoryGirl.create(:idea)
       @i2 = FactoryGirl.create(:idea)
       
-      @i1.users << @user
-      @i2.users << @user
+      @i1.user = @user
+      @i2.user = @user
+      
+      @i1.save
+      @i2.save
     end
     
     it "has an ideas attribute" do
@@ -173,9 +176,6 @@ describe User do
       
       @s = FactoryGirl.create(:spark)
       @i = FactoryGirl.create(:idea)
-      
-      @s.users << @user
-      @i.users << @user
       
       @c1 = FactoryGirl.create(:comment)
       @c2 = FactoryGirl.create(:comment)

--- a/web/spec/spec_helper.rb
+++ b/web/spec/spec_helper.rb
@@ -16,6 +16,7 @@ RSpec.configure do |config|
   # config.mock_with :flexmock
   # config.mock_with :rr
   config.mock_with :rspec
+  config.before(:all) { @auth_token = "0577a090fea6e735f471d349b14456ea34924b00" }
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
I changed the User-Idea relationship to now be a one-to-many relationship, using a migration which, when run, should convert all our existing relationships between the two models to this new one. BC, when you push this to Heroku, please be sure to run `rake db:migrate` to ensure my changes get pushed to the Heroku databse.

I also added preliminary API token authentication, since I figure that we only want to allow API requests from our own Android app. Out of respect for the Android team, I haven't flipped the switch on this yet, but we should figure out a way to create a token which isn't accessible or viewable on GitHub (because our github repos are public). For now, this code is commented out, but once we make the app available it'll definitely need to be enabled.

Many of the changes in this pull request are also just simple refactorings, making the code clearer and more concise.
