### PR TITLE
Redesigned Comments API

### DIFF
--- a/web/app/controllers/application_controller.rb
+++ b/web/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  
   protect_from_forgery
   
   before_filter :verify_security_token

--- a/web/app/controllers/v1/tags_controller.rb
+++ b/web/app/controllers/v1/tags_controller.rb
@@ -20,4 +20,5 @@ class V1::TagsController < ApplicationController
       format.json { render :json => @tag }
     end
   end
+  
 end

--- a/web/app/controllers/v1/users_controller.rb
+++ b/web/app/controllers/v1/users_controller.rb
@@ -43,4 +43,5 @@ class V1::UsersController < ApplicationController
     
     head :no_content
   end
+  
 end

--- a/web/app/models/idea.rb
+++ b/web/app/models/idea.rb
@@ -13,7 +13,6 @@ class Idea < ActiveRecord::Base
   attr_accessible :description
   
   belongs_to :user
-  # has_and_belongs_to_many :users
   has_and_belongs_to_many :sparks
   has_many :comments, :as => :commentable, :dependent => :destroy
   has_many :tags, :through => :tag_linkers

--- a/web/app/models/idea.rb
+++ b/web/app/models/idea.rb
@@ -13,7 +13,7 @@ class Idea < ActiveRecord::Base
   attr_accessible :description
   
   belongs_to :user
-  has_and_belongs_to_many :users
+  # has_and_belongs_to_many :users
   has_and_belongs_to_many :sparks
   has_many :comments, :as => :commentable, :dependent => :destroy
   has_many :tags, :through => :tag_linkers

--- a/web/config/routes.rb
+++ b/web/config/routes.rb
@@ -5,10 +5,14 @@ Steamnet::Application.routes.draw do
     namespace :v1 do
       
       resources :tags, :only => [:index, :show]
-      resources :comments, :except => [:new, :edit]
-      resources :sparks, :except => [:new, :edit, :update]
+      # resources :comments, :except => [:new, :edit]
+      resources :sparks, :except => [:new, :edit, :update] do
+        resources :comments, :except => [:new, :edit, :update]
+      end
       resources :users, :except => [:new, :edit]
-      resources :ideas, :except => [:new, :edit, :update]
+      resources :ideas, :except => [:new, :edit, :update] do
+        resources :comments, :except => [:new, :edit, :update]
+      end
       
       get "jawns" => "jawns#index"
       

--- a/web/config/routes.rb
+++ b/web/config/routes.rb
@@ -23,25 +23,28 @@ Steamnet::Application.routes.draw do
 end
 
 #== Route Map
-# Generated on 16 Jun 2013 11:41
+# Generated on 20 Jun 2013 15:31
 #
-#      v1_tag GET    /api/v1/tags/:id(.:format)     v1/tags#show
-# v1_comments GET    /api/v1/comments(.:format)     v1/comments#index
-#             POST   /api/v1/comments(.:format)     v1/comments#create
-#  v1_comment GET    /api/v1/comments/:id(.:format) v1/comments#show
-#             PUT    /api/v1/comments/:id(.:format) v1/comments#update
-#             DELETE /api/v1/comments/:id(.:format) v1/comments#destroy
-#   v1_sparks GET    /api/v1/sparks(.:format)       v1/sparks#index
-#             POST   /api/v1/sparks(.:format)       v1/sparks#create
-#    v1_spark GET    /api/v1/sparks/:id(.:format)   v1/sparks#show
-#             DELETE /api/v1/sparks/:id(.:format)   v1/sparks#destroy
-#    v1_users GET    /api/v1/users(.:format)        v1/users#index
-#             POST   /api/v1/users(.:format)        v1/users#create
-#     v1_user GET    /api/v1/users/:id(.:format)    v1/users#show
-#             PUT    /api/v1/users/:id(.:format)    v1/users#update
-#             DELETE /api/v1/users/:id(.:format)    v1/users#destroy
-#    v1_ideas GET    /api/v1/ideas(.:format)        v1/ideas#index
-#             POST   /api/v1/ideas(.:format)        v1/ideas#create
-#     v1_idea GET    /api/v1/ideas/:id(.:format)    v1/ideas#show
-#             DELETE /api/v1/ideas/:id(.:format)    v1/ideas#destroy
-#    v1_jawns GET    /api/v1/jawns(.:format)        v1/jawns#index
+#            v1_tag GET    /api/v1/tags/:id(.:format)                      v1/tags#show
+# v1_spark_comments GET    /api/v1/sparks/:spark_id/comments(.:format)     v1/comments#index
+#                   POST   /api/v1/sparks/:spark_id/comments(.:format)     v1/comments#create
+#  v1_spark_comment GET    /api/v1/sparks/:spark_id/comments/:id(.:format) v1/comments#show
+#                   DELETE /api/v1/sparks/:spark_id/comments/:id(.:format) v1/comments#destroy
+#         v1_sparks GET    /api/v1/sparks(.:format)                        v1/sparks#index
+#                   POST   /api/v1/sparks(.:format)                        v1/sparks#create
+#          v1_spark GET    /api/v1/sparks/:id(.:format)                    v1/sparks#show
+#                   DELETE /api/v1/sparks/:id(.:format)                    v1/sparks#destroy
+#          v1_users GET    /api/v1/users(.:format)                         v1/users#index
+#                   POST   /api/v1/users(.:format)                         v1/users#create
+#           v1_user GET    /api/v1/users/:id(.:format)                     v1/users#show
+#                   PUT    /api/v1/users/:id(.:format)                     v1/users#update
+#                   DELETE /api/v1/users/:id(.:format)                     v1/users#destroy
+#  v1_idea_comments GET    /api/v1/ideas/:idea_id/comments(.:format)       v1/comments#index
+#                   POST   /api/v1/ideas/:idea_id/comments(.:format)       v1/comments#create
+#   v1_idea_comment GET    /api/v1/ideas/:idea_id/comments/:id(.:format)   v1/comments#show
+#                   DELETE /api/v1/ideas/:idea_id/comments/:id(.:format)   v1/comments#destroy
+#          v1_ideas GET    /api/v1/ideas(.:format)                         v1/ideas#index
+#                   POST   /api/v1/ideas(.:format)                         v1/ideas#create
+#           v1_idea GET    /api/v1/ideas/:id(.:format)                     v1/ideas#show
+#                   DELETE /api/v1/ideas/:id(.:format)                     v1/ideas#destroy
+#          v1_jawns GET    /api/v1/jawns(.:format)                         v1/jawns#index

--- a/web/spec/controllers/v1/comments_controller_spec.rb
+++ b/web/spec/controllers/v1/comments_controller_spec.rb
@@ -2,6 +2,303 @@ require 'spec_helper'
 
 describe V1::CommentsController do
   
+  before(:each) do
+    @user = FactoryGirl.create(:user)
+    
+    @spark = FactoryGirl.create(:spark)
+    @idea = FactoryGirl.create(:idea)
+  end
   
+  describe "GET 'index'" do
+    
+    before(:each) do
+      @spark_comments = []
+      @idea_comments = []
+      
+      20.times do
+        comment = FactoryGirl.create(:comment)
+        comment.user = @user
+        
+        if [true, false].sample
+          comment.commentable = @spark
+          @spark_comments << comment
+        else
+          comment.commentable = @idea
+          @idea_comments << comment
+        end
+        
+        comment.save
+      end
+    end
+    
+    describe "on Sparks" do
+      
+      it "is successful" do
+        get :index, :spark_id => @spark, :format => 'json', :token => @auth_token
+        response.should be_success
+      end
+
+      it "returns the correct comments" do
+        get :index, :spark_id => @spark, :format => 'json', :token => @auth_token
+        response.body.should == @spark_comments.to_json
+      end
+      
+    end
+    
+    describe "on Ideas" do
+      
+      it "is successful" do
+        get :index, :idea_id => @idea, :format => 'json', :token => @auth_token
+        response.should be_success
+      end
+
+      it "returns the correct comments" do
+        get :index, :idea_id => @idea, :format => 'json', :token => @auth_token
+        response.body.should == @idea_comments.to_json
+      end
+      
+    end
+    
+  end
+  
+  describe "GET 'show'" do
+    
+    before(:each) do
+      @spark_comment = FactoryGirl.create(:comment)
+      @spark_comment.user = @user
+      @spark_comment.commentable = @spark
+      
+      @spark_comment.save
+      
+      @idea_comment = FactoryGirl.create(:comment)
+      @idea_comment.user = @user
+      @idea_comment.commentable = @idea
+      
+      @idea_comment.save
+    end
+    
+    describe "on a Spark" do
+      
+      describe "with a valid comment id" do
+        
+        it "is successful" do
+          get :show, :spark_id => @spark, :id => @spark_comment, :format => 'json', :token => @auth_token
+          response.should be_success
+        end
+
+        it "returns the correct comment" do
+          get :show, :spark_id => @spark, :id => @spark_comment, :format => 'json', :token => @auth_token
+          response.body.should == @spark_comment.to_json
+        end
+        
+      end
+      
+      describe "with an invalid comment id" do
+        
+        it "isn't successful" do
+          get :show, :spark_id => @spark, :id => @idea_comment, :format => 'json', :token => @auth_token
+          response.should_not be_success
+        end
+        
+      end
+      
+    end
+    
+    describe "on an Idea" do
+      
+      describe "with a valid comment id" do
+        
+        it "is successful" do
+          get :show, :idea_id => @idea, :id => @idea_comment, :format => 'json', :token => @auth_token
+          response.should be_success
+        end
+
+        it "returns the correct comment" do
+          get :show, :idea_id => @idea, :id => @idea_comment, :format => 'json', :token => @auth_token
+          response.body.should == @idea_comment.to_json
+        end
+        
+      end
+      
+      describe "with an invalid comment id" do
+        
+        it "isn't successful" do
+          get :show, :idea_id => @idea, :id => @spark_comment, :format => 'json', :token => @auth_token
+          response.should_not be_success
+        end
+        
+      end
+      
+    end
+    
+  end
+  
+  describe "POST 'create'" do
+    
+    before(:each) do
+      @attr = {
+        :comment_text => "This is a comment!"
+      }
+    end
+    
+    describe "on a Spark" do
+      
+      it "is successful" do
+        post :create, :spark_id => @spark, :comment => @attr, :username => @user.name, :format => 'json', :token => @auth_token
+        response.should be_success
+      end
+    
+      it "should create the comment" do
+        expect {
+          post :create, :spark_id => @spark, :comment => @attr, :username => @user.name, :format => 'json', :token => @auth_token
+        }.to change { Comment.count }.by(1)
+      end
+      
+      it "should return the comment" do
+        post :create, :spark_id => @spark, :comment => @attr, :username => @user.name, :format => 'json', :token => @auth_token
+        response.body.should == Comment.last.to_json
+      end
+      
+      it "should associate the user and the comment" do
+        post :create, :spark_id => @spark, :comment => @attr, :username => @user.name, :format => 'json', :token => @auth_token
+        comment = Comment.last
+        comment.user.should == @user
+      end
+      
+      it "should associate the spark and the comment" do
+        post :create, :spark_id => @spark, :comment => @attr, :username => @user.name, :format => 'json', :token => @auth_token
+        comment = Comment.last
+        comment.commentable.should == @spark
+      end
+      
+    end
+    
+    describe "on an Idea" do
+      
+      it "is successful" do
+        post :create, :idea_id => @idea, :comment => @attr, :username => @user.name, :format => 'json', :token => @auth_token
+        response.should be_success
+      end
+    
+      it "should create the comment" do
+        expect {
+          post :create, :idea_id => @idea, :comment => @attr, :username => @user.name, :format => 'json', :token => @auth_token
+        }.to change { Comment.count }.by(1)
+      end
+      
+      it "should return the comment" do
+        post :create, :idea_id => @idea, :comment => @attr, :username => @user.name, :format => 'json', :token => @auth_token
+        response.body.should == Comment.last.to_json
+      end
+      
+      it "should associate the user and the comment" do
+        post :create, :idea_id => @idea, :comment => @attr, :username => @user.name, :format => 'json', :token => @auth_token
+        comment = Comment.last
+        comment.user.should == @user
+      end
+      
+      it "should associate the idea and the comment" do
+        post :create, :idea_id => @idea, :comment => @attr, :username => @user.name, :format => 'json', :token => @auth_token
+        comment = Comment.last
+        comment.commentable.should == @idea
+      end
+      
+    end
+    
+  end
+  
+  describe "DELETE 'destroy'" do
+    
+    before(:each) do
+      @comment = FactoryGirl.create(:comment)
+      @comment.user = @user
+      @comment.save
+    end
+    
+    describe "on a Spark" do
+      
+      before(:each) do
+        @comment.commentable = @spark
+      end
+      
+      describe "with the correct user" do
+        
+        it "is successful" do
+          delete :destroy, :spark_id => @spark, :id => @comment, :username => @user.name, :format => 'json', :token => @auth_token
+          response.should be_success
+        end
+
+        it "destroys the comment" do
+          expect {
+            delete :destroy, :spark_id => @spark, :id => @comment, :username => @user.name, :format => 'json', :token => @auth_token
+          }.to change { Comment.count }.by(-1)
+        end
+        
+      end
+      
+      describe "with the wrong user" do
+        
+        before(:each) do
+          @wrong_user = FactoryGirl.create(:user)
+        end
+        
+        it "isn't successful" do
+          delete :destroy, :spark_id => @spark, :id => @comment, :username => @wrong_user.name, :format => 'json', :token => @auth_token
+          response.should be_success
+        end
+
+        it "doesn't destroy the comment" do
+          expect {
+            delete :destroy, :spark_id => @spark, :id => @comment, :username => @wrong_user.name, :format => 'json', :token => @auth_token
+          }.not_to change { Comment.count }
+        end
+        
+      end
+      
+    end
+    
+    describe "on an Idea" do
+      
+      before(:each) do
+        @comment.commentable = @idea
+      end
+      
+      describe "with the correct user" do
+        
+        it "is successful" do
+          delete :destroy, :idea_id => @idea, :id => @comment, :username => @user.name, :format => 'json', :token => @auth_token
+          response.should be_success
+        end
+
+        it "destroys the comment" do
+          expect {
+            delete :destroy, :idea_id => @idea, :id => @comment, :username => @user.name, :format => 'json', :token => @auth_token
+          }.to change { Comment.count }.by(-1)
+        end
+        
+      end
+      
+      describe "with the wrong user" do
+        
+        before(:each) do
+          @wrong_user = FactoryGirl.create(:user)
+        end
+        
+        it "isn't successful" do
+          delete :destroy, :idea_id => @idea, :id => @comment, :username => @wrong_user.name, :format => 'json', :token => @auth_token
+          response.should be_success
+        end
+
+        it "doesn't destroy the comment" do
+          expect {
+            delete :destroy, :idea_id => @idea, :id => @comment, :username => @wrong_user.name, :format => 'json', :token => @auth_token
+          }.not_to change { Comment.count }
+        end
+        
+      end
+      
+    end
+    
+  end
   
 end

--- a/web/spec/controllers/v1/comments_controller_spec.rb
+++ b/web/spec/controllers/v1/comments_controller_spec.rb
@@ -161,13 +161,13 @@ describe V1::CommentsController do
       
       it "should associate the user and the comment" do
         post :create, :spark_id => @spark, :comment => @attr, :username => @user.name, :format => 'json', :token => @auth_token
-        comment = Comment.last
+        comment = Comment.find_by_comment_text(@attr[:comment_text])
         comment.user.should == @user
       end
       
       it "should associate the spark and the comment" do
         post :create, :spark_id => @spark, :comment => @attr, :username => @user.name, :format => 'json', :token => @auth_token
-        comment = Comment.last
+        comment = Comment.find_by_comment_text(@attr[:comment_text])
         comment.commentable.should == @spark
       end
       
@@ -219,6 +219,7 @@ describe V1::CommentsController do
       
       before(:each) do
         @comment.commentable = @spark
+        @comment.save
       end
       
       describe "with the correct user" do
@@ -244,7 +245,7 @@ describe V1::CommentsController do
         
         it "isn't successful" do
           delete :destroy, :spark_id => @spark, :id => @comment, :username => @wrong_user.name, :format => 'json', :token => @auth_token
-          response.should be_success
+          response.should_not be_success
         end
 
         it "doesn't destroy the comment" do
@@ -261,6 +262,7 @@ describe V1::CommentsController do
       
       before(:each) do
         @comment.commentable = @idea
+        @comment.save
       end
       
       describe "with the correct user" do
@@ -286,7 +288,7 @@ describe V1::CommentsController do
         
         it "isn't successful" do
           delete :destroy, :idea_id => @idea, :id => @comment, :username => @wrong_user.name, :format => 'json', :token => @auth_token
-          response.should be_success
+          response.should_not be_success
         end
 
         it "doesn't destroy the comment" do

--- a/web/spec/routing/comments_routing_spec.rb
+++ b/web/spec/routing/comments_routing_spec.rb
@@ -2,47 +2,88 @@ require 'spec_helper'
 
 describe "routes for Comments" do
   
-  it "routes get /api/v1/comments.json to Comments controller" do
-    { :get => "/api/v1/comments.json" }.should route_to(
-      :controller => "v1/comments",
-      :action => "index",
-      :format => "json"
-    )
+  describe "on Sparks" do
+    
+    it "routes get /api/v1/sparks/:spark_id/comments.json to Comments controller" do
+      { :get => "/api/v1/sparks/1/comments.json" }.should route_to(
+        :controller => "v1/comments",
+        :action => "index",
+        :spark_id => "1",
+        :format => "json"
+      )
+    end
+
+    it "routes post /api/v1/sparks/:spark_id/comments.json to Comments controller" do
+      { :post => "/api/v1/sparks/1/comments.json" }.should route_to(
+        :controller => "v1/comments",
+        :action => "create",
+        :spark_id => "1",
+        :format => "json"
+      )
+    end
+
+    it "routes get /api/v1/sparks/:spark_id/comments/:id.json to Comments controller" do
+      { :get => "/api/v1/sparks/1/comments/1.json" }.should route_to(
+        :controller => "v1/comments",
+        :action => "show",
+        :spark_id => "1",
+        :id => "1",
+        :format => "json"
+      )
+    end
+    
+    it "routes delete /api/v1/sparks/:spark_id/comments/:id.json to Comments controller" do
+      { :delete => "/api/v1/sparks/1/comments/1.json" }.should route_to(
+        :controller => "v1/comments",
+        :action => "destroy",
+        :spark_id => "1",
+        :id => "1",
+        :format => "json"
+      )
+    end
+    
   end
   
-  it "routes post /api/v1/comments.json to Comments controller" do
-    { :post => "/api/v1/comments.json" }.should route_to(
-      :controller => "v1/comments",
-      :action => "create",
-      :format => "json"
-    )
-  end
-  
-  it "routes get /api/v1/comments/:id.json to Comments controller" do
-    { :get => "/api/v1/comments/1.json" }.should route_to(
-      :controller => "v1/comments",
-      :action => "show",
-      :id => "1",
-      :format => "json"
-    )
-  end
-  
-  it "routes put /api/v1/comments/:id.json to Comments controller" do
-    { :put => "/api/v1/comments/1.json" }.should route_to(
-      :controller => "v1/comments",
-      :action => "update",
-      :id => "1",
-      :format => "json"
-    )
-  end
-  
-  it "routes delete /api/v1/comments/:id.json to Comments controller" do
-    { :delete => "/api/v1/comments/1.json" }.should route_to(
-      :controller => "v1/comments",
-      :action => "destroy",
-      :id => "1",
-      :format => "json"
-    )
+  describe "on Ideas" do
+    
+    it "routes get /api/v1/ideas/:idea_id/comments.json to Comments controller" do
+      { :get => "/api/v1/ideas/1/comments.json" }.should route_to(
+        :controller => "v1/comments",
+        :action => "index",
+        :idea_id => "1",
+        :format => "json"
+      )
+    end
+
+    it "routes post /api/v1/ideas/:idea_id/comments.json to Comments controller" do
+      { :post => "/api/v1/ideas/1/comments.json" }.should route_to(
+        :controller => "v1/comments",
+        :action => "create",
+        :idea_id => "1",
+        :format => "json"
+      )
+    end
+
+    it "routes get /api/v1/ideas/:idea_id/comments/:id.json to Comments controller" do
+      { :get => "/api/v1/ideas/1/comments/1.json" }.should route_to(
+        :controller => "v1/comments",
+        :action => "show",
+        :idea_id => "1",
+        :id => "1",
+        :format => "json"
+      )
+    end
+
+    it "routes delete /api/v1/ideas/:idea_id/comments/:id.json to Comments controller" do
+      { :delete => "/api/v1/ideas/1/comments/1.json" }.should route_to(
+        :controller => "v1/comments",
+        :action => "destroy",
+        :idea_id => "1",
+        :id => "1",
+        :format => "json"
+      )
+    end
+    
   end
   
 end


### PR DESCRIPTION
Accessing comments is now done as a subset of a spark or idea, to list all the comments of a specific spark or idea, or to create a comment which automatically associates with a given spark or idea.

Whereas before, one would create a new comment by sending a request to `/api/v1/comments.json`, with a given spark or idea as an attribute passed in, instead a request must be made to `/api/v1/sparks/1/comments.json`, which will add a comment to the Spark with an id of 1. The same goes for ideas.

Sam, I hope this doesn't mean you have to change too much code on the android side, but I think this system makes for a much cleaner API.
