### PR TITLE
Content/Spark type validations

### DIFF
--- a/web/app/models/spark.rb
+++ b/web/app/models/spark.rb
@@ -22,7 +22,7 @@ class Spark < ActiveRecord::Base
   has_many :tags, :through => :tag_linkers
   has_many :tag_linkers, :as => :tagable
   
-  validates :content_type, :presence => true, :format => { :with => /^[LVCTPAV]$/, :message => "must be a valid content type" }
+  validates :content_type, :presence => true, :format => { :with => /^[LVCTPA]$/, :message => "must be a valid content type" }
   validates :content, :presence => true
   validates :content_hash, :presence => true, :uniqueness => true
   validates :spark_type, :presence => true, :format => { :with => /^[WIP]$/, :message => "must be a valid spark type" }

--- a/web/app/models/spark.rb
+++ b/web/app/models/spark.rb
@@ -3,8 +3,8 @@
 # Table name: sparks
 #
 #  id           :integer          not null, primary key
-#  spark_type   :string(255)
-#  content_type :string(255)
+#  spark_type   :string(1)
+#  content_type :string(1)
 #  content      :text
 #  content_hash :string(255)
 #  created_at   :datetime         not null

--- a/web/app/models/spark.rb
+++ b/web/app/models/spark.rb
@@ -22,10 +22,10 @@ class Spark < ActiveRecord::Base
   has_many :tags, :through => :tag_linkers
   has_many :tag_linkers, :as => :tagable
   
-  validates :content_type, :presence => true
+  validates :content_type, :presence => true, :format => { :with => /^[LVCTPAV]$/, :message => "must be a valid content type" }
   validates :content, :presence => true
   validates :content_hash, :presence => true, :uniqueness => true
-  validates :spark_type, :presence => true
+  validates :spark_type, :presence => true, :format => { :with => /^[WIP]$/, :message => "must be a valid spark type" }
   
   before_validation :hash_content
   

--- a/web/app/models/tag.rb
+++ b/web/app/models/tag.rb
@@ -19,7 +19,7 @@ class Tag < ActiveRecord::Base
   has_many :ideas, :through => :tag_linkers, :source => :tagable, :source_type => "Idea"
   has_many :tag_linkers
   
-  validates :tag_text, :presence => true, :format => { :with => /^[A-Za-z\d_-]+$/, :message => "must be alphanumerical." }, :uniqueness => { :case_sensitive => true }
+  validates :tag_text, :presence => true, :format => { :with => /^[A-Za-z\d_-]+$/, :message => "must be alphanumerical" }, :uniqueness => { :case_sensitive => true }
   
   def as_json(options={})
     super(:include => [:sparks, :ideas])

--- a/web/app/models/user.rb
+++ b/web/app/models/user.rb
@@ -23,8 +23,8 @@ class User < ActiveRecord::Base
   has_many :ideas
   has_many :comments
   
-  validates :email, :presence => true, :format => { :with => /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/, :message => "must be a valid email address." }, :uniqueness => { :case_sensitive => false }
-  validates :name, :presence => true, :format => { :with => /^[A-Za-z\d_-]+$/, :message => "must be alphanumerical." }, :uniqueness => { :case_sensitive => false }
+  validates :email, :presence => true, :format => { :with => /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/, :message => "must be a valid email address" }, :uniqueness => { :case_sensitive => false }
+  validates :name, :presence => true, :format => { :with => /^[A-Za-z\d_-]+$/, :message => "must be alphanumerical" }, :uniqueness => { :case_sensitive => false }
   validates :password, :presence => { :on => :create }
   
   def as_json(options={})

--- a/web/db/migrate/20130626185414_change_content_type_and_spark_type_length.rb
+++ b/web/db/migrate/20130626185414_change_content_type_and_spark_type_length.rb
@@ -1,0 +1,6 @@
+class ChangeContentTypeAndSparkTypeLength < ActiveRecord::Migration
+  def change
+    change_column :sparks, :spark_type, :string, :limit => 1
+    change_column :sparks, :content_type, :string, :limit => 1
+  end
+end

--- a/web/db/schema.rb
+++ b/web/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130623163343) do
+ActiveRecord::Schema.define(:version => 20130626185414) do
 
   create_table "comments", :force => true do |t|
     t.text     "comment_text"
@@ -35,12 +35,12 @@ ActiveRecord::Schema.define(:version => 20130623163343) do
   end
 
   create_table "sparks", :force => true do |t|
-    t.string   "spark_type"
-    t.string   "content_type"
+    t.string   "spark_type",   :limit => 1
+    t.string   "content_type", :limit => 1
     t.text     "content"
     t.string   "content_hash"
-    t.datetime "created_at",   :null => false
-    t.datetime "updated_at",   :null => false
+    t.datetime "created_at",                :null => false
+    t.datetime "updated_at",                :null => false
   end
 
   create_table "sparks_users", :id => false, :force => true do |t|

--- a/web/db/seeds.rb
+++ b/web/db/seeds.rb
@@ -1,7 +1,110 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ :name => 'Chicago' }, { :name => 'Copenhagen' }])
-#   Mayor.create(:name => 'Emanuel', :city => cities.first)
+
+require 'faker'
+
+names = %w[max colin aqeel sam drew dan heather grace]
+users = []
+
+names.each do |n|
+  users << User.create(:name => n, :email => Faker::Internet.email, :password => "password", :password_confirmation => "password")
+end
+
+tag_texts = %w[awesome purple yellow internet legit tablets android rails]
+tags = []
+
+tag_texts.each do |t|
+  tags << Tag.create(:tag_text => t)
+end
+
+content_types = %w[L C T P A V]
+spark_types = %w[W I P]
+
+pictures = %w[http://1.bp.blogspot.com/_mLv-KWFqzEU/TOoJBVb7NJI/AAAAAAAAABk/cj44CcZq6v8/s1600/sparks%2525205.jpg http://upload.wikimedia.org/wikipedia/commons/4/41/Space_Shuttle_Columbia_launching.jpg http://images2.fanpop.com/images/photos/5800000/happy-kitten-kittens-5890512-1600-1200.jpg]
+videos = %w[http://www.youtube.com/watch?v=j5C6X9vOEkU http://www.youtube.com/watch?v=1VuMdLm0ccU http://www.youtube.com/watch?v=oHg5SJYRHA0]
+audios = %w[http://soundcloud.com/se-beat/se-beat-straight-to-straight http://soundcloud.com/martin_lind/texture-vi http://soundcloud.com/martin_lind/suburbia-i-3]
+
+sparks = []
+
+content_types.each do |c|
+  spark_types.each do |s|
+    spark = Spark.new(:content_type => c, :spark_type => s)
+    
+    case c
+    when "L"
+      spark.content = Faker::Internet.url
+    when "C"
+      spark.content = "User.create!(:name => #{Faker::Internet.user_name})"
+    when "T"
+      spark.content = Faker::Lorem.sentences.join(" ")
+    when "P"
+      spark.content = pictures.pop
+    when "A"
+      spark.content = audios.pop
+    when "V"
+      spark.content = videos.pop
+    end
+    
+    spark.save
+    
+    (rand(4) + 1).times do
+      t = tags.sample
+      
+      unless(spark.tags.include?(t))
+        spark.tags << t
+      end
+    end
+    
+    (rand(3) + 1).times do
+      u = users.sample
+      
+      unless(spark.users.include?(u))
+        spark.users << u
+      end
+    end
+    
+    (rand(4)).times do
+      comment = Comment.new(:comment_text => Faker::Lorem.sentences.join(" "))
+      comment.user = users.sample
+      comment.commentable = spark
+      
+      comment.save
+    end
+    
+    sparks << spark
+  end
+end
+
+15.times do
+  idea = Idea.new(:description => Faker::Lorem.sentence)
+  idea.user = users.sample
+  
+  idea.save
+  
+  (rand(5) + 1).times do
+    s = sparks.sample
+    
+    unless(idea.sparks.include?(s))
+      idea.sparks << s
+    end
+  end
+  
+  (rand(4) + 1).times do
+    t = tags.sample
+    
+    unless(idea.tags.include?(t))
+      idea.tags << t
+    end
+  end
+  
+  (rand(4)).times do
+    comment = Comment.new(:comment_text => Faker::Lorem.sentences.join(" "))
+    comment.user = users.sample
+    comment.commentable = idea
+    
+    comment.save
+  end
+end
+
+puts users
+puts sparks

--- a/web/spec/models/spark_spec.rb
+++ b/web/spec/models/spark_spec.rb
@@ -35,10 +35,42 @@ describe Spark do
       spark.should_not be_valid
     end
     
+    it "accepts valid spark types" do
+      types = %w[W I P]
+      types.each do |t|
+        spark = Spark.new(@attr.merge(:spark_type => t))
+        spark.should be_valid
+      end
+    end
+    
+    it "rejects invalid spark types" do
+      types = %w[w i p some_type L l V v C c T t A a V v whatever]
+      types.each do |t|
+        spark = Spark.new(@attr.merge(:spark_type => t))
+        spark.should_not be_valid
+      end
+    end
+    
     it "requires a content type" do
       spark = Spark.new(@attr)
       spark.content_type = ""
       spark.should_not be_valid
+    end
+    
+    it "accepts valid content types" do
+      types = %w[L V C T P A V]
+      types.each do |t|
+        spark = Spark.new(@attr.merge(:content_type => t))
+        spark.should be_valid
+      end
+    end
+    
+    it "rejects invalid content types" do
+      types = %w[l v c t p a v W w I i some_type whatever]
+      types.each do |t|
+        spark = Spark.new(@attr.merge(:content_type => t))
+        spark.should_not be_valid
+      end
     end
     
     it "requires content" do

--- a/web/spec/models/spark_spec.rb
+++ b/web/spec/models/spark_spec.rb
@@ -58,7 +58,7 @@ describe Spark do
     end
     
     it "accepts valid content types" do
-      types = %w[L V C T P A V]
+      types = %w[L V C T P A]
       types.each do |t|
         spark = Spark.new(@attr.merge(:content_type => t))
         spark.should be_valid

--- a/web/spec/models/spark_spec.rb
+++ b/web/spec/models/spark_spec.rb
@@ -3,8 +3,8 @@
 # Table name: sparks
 #
 #  id           :integer          not null, primary key
-#  spark_type   :string(255)
-#  content_type :string(255)
+#  spark_type   :string(1)
+#  content_type :string(1)
 #  content      :text
 #  content_hash :string(255)
 #  created_at   :datetime         not null


### PR DESCRIPTION
Added validations to ensure that only Sparks with content_type L, V, C, T, P, or A are accepted into the database. I'm fairly sure that's every one we decided upon, but obviously it would be very easy to expand or change this list.

I also did the same thing with the spark_type attribute, limiting it to W, for What-If Question, P for Problem, and I for Inspiration.

BC, I also made a slight alteration to the database for these attributes, limiting each one to only one character in the database, so make sure to migrate the database when you push this to heorku.
