### PR TITLE
Jawns Controller random sorting hotfix

### DIFF
--- a/web/app/controllers/v1/jawns_controller.rb
+++ b/web/app/controllers/v1/jawns_controller.rb
@@ -15,7 +15,7 @@ class V1::JawnsController < ApplicationController
         sparks = Spark.limit(params[:limit])
         ideas = Idea.limit(params[:limit])
         
-        int = ((seed + 1) * 10).to_i
+        int = ((seed + 1) * 10000).to_i
         @jawns = (sparks + ideas).shuffle(random: Random.new(int))
 
         if params[:offset]

--- a/web/spec/controllers/v1/jawns_controller_spec.rb
+++ b/web/spec/controllers/v1/jawns_controller_spec.rb
@@ -118,7 +118,7 @@ describe V1::JawnsController do
         output.should be_a_kind_of(Array)
         output.length.should == @jawns.length
         
-        jawns = (Spark.all + Idea.all).shuffle(random: Random.new((seed+1)*10))
+        jawns = (Spark.all + Idea.all).shuffle(random: Random.new((seed+1)*10000))
         
         output.each_with_index do |jawn, index|
           jawn["jawn_type"].should == jawns[index].class.to_s.downcase


### PR DESCRIPTION
Fixed issue from [Pull #75](https://github.com/cangevine/STEAMnet/pull/75) where the Jawns Controller only accepted seeds for one significant digit, which would only allow 10 different orders of Jawns.
