### PR TITLE
Lite response for Sparks and Ideas

### DIFF
--- a/web/app/views/v1/ideas/_idea.json.jbuilder
+++ b/web/app/views/v1/ideas/_idea.json.jbuilder
@@ -1,16 +1,18 @@
 json.(idea, :id, :created_at, :description)
 
-json.user idea.user, :id, :name, :email if idea.user
+unless lite
+  json.user idea.user, :id, :name, :email if idea.user
 
-json.sparks idea.sparks do |spark|
-  json.(spark, :id, :created_at, :spark_type, :content_type, :content, :content_hash)
-  json.file spark.file.url if spark.file.exists?
+  json.sparks idea.sparks do |spark|
+    json.(spark, :id, :created_at, :spark_type, :content_type, :content, :content_hash)
+    json.file spark.file.url if spark.file.exists?
+  end
+
+  json.comments idea.comments do |comment|
+    json.(comment, :id, :comment_text, :created_at)
+    json.user comment.user, :id, :name, :email
+  end
+
+  tag_names = idea.tags.map(&:tag_text)
+  json.tags tag_names
 end
-
-json.comments idea.comments do |comment|
-  json.(comment, :id, :comment_text, :created_at)
-  json.user comment.user, :id, :name, :email
-end
-
-tag_names = idea.tags.map(&:tag_text)
-json.tags tag_names

--- a/web/app/views/v1/ideas/index.json.jbuilder
+++ b/web/app/views/v1/ideas/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @ideas do |idea|
-  json.partial! 'idea', idea: idea
+  json.partial! 'idea', idea: idea, lite: params[:lite] == "true"
 end

--- a/web/app/views/v1/ideas/show.json.jbuilder
+++ b/web/app/views/v1/ideas/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'idea', idea: @idea
+json.partial! 'idea', idea: @idea, lite: params[:lite] == "true"

--- a/web/app/views/v1/jawns/index.json.jbuilder
+++ b/web/app/views/v1/jawns/index.json.jbuilder
@@ -1,30 +1,14 @@
-# if params[:lite] == "true"
-#   json.array! @jawns do |jawn|
-#     type = jawn.class.to_s.downcase
-#     
-#     case type
-#     when "spark"
-#       json.(jawn, :id, :created_at, :spark_type, :content_type, :content, :content_hash)
-#       json.file jawn.file.url if jawn.file.exists?
-#     when "idea"
-#       json.(jawn, :id, :description, :created_at)
-#     end
-#     
-#     json.jawn_type type
-#   end
-# else
-  lite = params[:lite] == "true"
+lite = params[:lite] == "true"
+
+json.array! @jawns do |jawn|
+  type = jawn.class.to_s.downcase
   
-  json.array! @jawns do |jawn|
-    type = jawn.class.to_s.downcase
-    
-    case type
-    when "spark"
-      json.partial! 'v1/sparks/spark', spark: jawn, lite: lite
-    when "idea"
-      json.partial! 'v1/ideas/idea', idea: jawn, lite: lite
-    end
-    
-    json.jawn_type type
+  case type
+  when "spark"
+    json.partial! 'v1/sparks/spark', spark: jawn, lite: lite
+  when "idea"
+    json.partial! 'v1/ideas/idea', idea: jawn, lite: lite
   end
-# end
+  
+  json.jawn_type type
+end

--- a/web/app/views/v1/jawns/index.json.jbuilder
+++ b/web/app/views/v1/jawns/index.json.jbuilder
@@ -1,28 +1,30 @@
-if params[:lite] == "true"
+# if params[:lite] == "true"
+#   json.array! @jawns do |jawn|
+#     type = jawn.class.to_s.downcase
+#     
+#     case type
+#     when "spark"
+#       json.(jawn, :id, :created_at, :spark_type, :content_type, :content, :content_hash)
+#       json.file jawn.file.url if jawn.file.exists?
+#     when "idea"
+#       json.(jawn, :id, :description, :created_at)
+#     end
+#     
+#     json.jawn_type type
+#   end
+# else
+  lite = params[:lite] == "true"
+  
   json.array! @jawns do |jawn|
     type = jawn.class.to_s.downcase
     
     case type
     when "spark"
-      json.(jawn, :id, :created_at, :spark_type, :content_type, :content, :content_hash)
-      json.file jawn.file.url if jawn.file.exists?
+      json.partial! 'v1/sparks/spark', spark: jawn, lite: lite
     when "idea"
-      json.(jawn, :id, :description, :created_at)
+      json.partial! 'v1/ideas/idea', idea: jawn, lite: lite
     end
     
     json.jawn_type type
   end
-else
-  json.array! @jawns do |jawn|
-    type = jawn.class.to_s.downcase
-    
-    case type
-    when "spark"
-      json.partial! 'v1/sparks/spark', spark: jawn
-    when "idea"
-      json.partial! 'v1/ideas/idea', idea: jawn
-    end
-    
-    json.jawn_type type
-  end
-end
+# end

--- a/web/app/views/v1/sparks/_spark.json.jbuilder
+++ b/web/app/views/v1/sparks/_spark.json.jbuilder
@@ -1,15 +1,16 @@
 json.(spark, :id, :created_at, :spark_type, :content_type, :content, :content_hash)
-
 json.file spark.file.url if spark.file.exists?
 
-json.users spark.users, :id, :name, :email
+unless lite
+  json.users spark.users, :id, :name, :email
 
-json.ideas spark.ideas, :id, :created_at, :description
+  json.ideas spark.ideas, :id, :created_at, :description
 
-json.comments spark.comments do |comment|
-  json.(comment, :id, :comment_text, :created_at)
-  json.user comment.user, :id, :name, :email
+  json.comments spark.comments do |comment|
+    json.(comment, :id, :comment_text, :created_at)
+    json.user comment.user, :id, :name, :email
+  end
+
+  tag_names = spark.tags.map(&:tag_text)
+  json.tags tag_names
 end
-
-tag_names = spark.tags.map(&:tag_text)
-json.tags tag_names

--- a/web/app/views/v1/sparks/index.json.jbuilder
+++ b/web/app/views/v1/sparks/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @sparks do |spark|
-  json.partial! 'spark', spark: spark
+  json.partial! 'spark', spark: spark, lite: params["lite"] == "true"
 end

--- a/web/app/views/v1/sparks/show.json.jbuilder
+++ b/web/app/views/v1/sparks/show.json.jbuilder
@@ -1,2 +1,2 @@
 json.spark_is_new true if @spark_is_new
-json.partial! 'spark', spark: @spark
+json.partial! 'spark', spark: @spark, lite: params["lite"] == "true"

--- a/web/spec/controllers/v1/ideas_controller_spec.rb
+++ b/web/spec/controllers/v1/ideas_controller_spec.rb
@@ -43,6 +43,23 @@ describe V1::IdeasController do
       end
     end
     
+    describe "lite response" do
+      
+      it "only returns ids and stuff" do
+        get :index, :format => 'json', :lite => "true", :token => @auth_token
+        output = JSON.parse(response.body)
+        
+        output.should be_a_kind_of(Array)
+        
+        output.each do |idea|
+          idea["id"].should_not be_nil
+          idea["user"].should be_nil
+          idea["sparks"].should be_nil
+        end
+      end
+      
+    end
+    
   end
   
   describe "GET 'show'" do
@@ -62,6 +79,21 @@ describe V1::IdeasController do
       
       output.should be_a_kind_of(Hash)
       output["description"].should == @idea.description
+    end
+    
+    describe "lite response" do
+      
+      it "only returns id and stuff" do
+        get :show, :id => @idea, :format => 'json', :lite => "true", :token => @auth_token
+        output = JSON.parse(response.body)
+        
+        output.should be_a_kind_of(Hash)
+        
+        output["id"].should_not be_nil
+        output["user"].should be_nil
+        output["sparks"].should be_nil
+      end
+      
     end
     
   end

--- a/web/spec/controllers/v1/sparks_controller_spec.rb
+++ b/web/spec/controllers/v1/sparks_controller_spec.rb
@@ -43,6 +43,23 @@ describe V1::SparksController do
       end
     end
     
+    describe "lite response" do
+      
+      it "only returns ids and stuff" do
+        get :index, :format => 'json', :lite => "true", :token => @auth_token
+        output = JSON.parse(response.body)
+        
+        output.should be_a_kind_of(Array)
+        
+        output.each do |spark|
+          spark["id"].should_not be_nil
+          spark["users"].should be_nil
+          spark["ideas"].should be_nil
+        end
+      end
+      
+    end
+    
   end
   
   describe "GET 'show'" do
@@ -63,6 +80,21 @@ describe V1::SparksController do
       output.should be_a_kind_of(Hash)
       output["content_hash"].should == @spark.content_hash
       output["file"].should_not be_nil
+    end
+    
+    describe "lite response" do
+      
+      it "only returns id and stuff" do
+        get :show, :id => @spark, :format => 'json', :lite => "true", :token => @auth_token
+        output = JSON.parse(response.body)
+        
+        output.should be_a_kind_of(Hash)
+        
+        output["id"].should_not be_nil
+        output["users"].should be_nil
+        output["ideas"].should be_nil
+      end
+      
     end
     
   end


### PR DESCRIPTION
Added lite response functionality to Sparks and Ideas controllers. This can now be used for individual sparks or ideas, with `/api/v1/ideas|sparks/id.json?lite=true`, or for the lists of sparks or ideas, with `/api/v1/ideas|sparks.json?lite=true`, and works the same way it does for the Jawns controller.
