### PR TITLE
Enable token authentication for Spark/Idea/Comment creation/deletion

### DIFF
--- a/web/app/controllers/application_controller.rb
+++ b/web/app/controllers/application_controller.rb
@@ -2,23 +2,15 @@ class ApplicationController < ActionController::Base
   
   protect_from_forgery
   
-  # before_action :authenticate
-  
   private
     
-    def authenticate_new
+    def authenticate
       device = Device.find_by(token: params[:token])
       
-      head :unauthorized unless device
-      
-      @user = device.user
-    end
-    
-    def authenticate
-      @user = User.find_by(name: params[:username])
-      
-      unless @user
-        hash = { :error => "Invalid username." }
+      if device
+        @user = device.user
+      else
+        hash = { :error => "Invalid token." }
         respond_to do |format|
           format.json { render :json => hash, :status => :unauthorized }
         end

--- a/web/app/views/v1/ideas/_idea.json.jbuilder
+++ b/web/app/views/v1/ideas/_idea.json.jbuilder
@@ -1,16 +1,18 @@
 json.(idea, :id, :created_at, :description)
 
-json.user idea.user, :id, :name, :email if idea.user
+unless lite
+  json.user idea.user, :id, :name, :email if idea.user
 
-json.sparks idea.sparks do |spark|
-  json.(spark, :id, :created_at, :spark_type, :content_type, :content, :content_hash)
-  json.file spark.file.url if spark.file.exists?
+  json.sparks idea.sparks do |spark|
+    json.(spark, :id, :created_at, :spark_type, :content_type, :content, :content_hash)
+    json.file spark.file.url if spark.file.exists?
+  end
+
+  json.comments idea.comments do |comment|
+    json.(comment, :id, :comment_text, :created_at)
+    json.user comment.user, :id, :name, :email
+  end
+
+  tag_names = idea.tags.map(&:tag_text)
+  json.tags tag_names
 end
-
-json.comments idea.comments do |comment|
-  json.(comment, :id, :comment_text, :created_at)
-  json.user comment.user, :id, :name, :email
-end
-
-tag_names = idea.tags.map(&:tag_text)
-json.tags tag_names

--- a/web/app/views/v1/ideas/index.json.jbuilder
+++ b/web/app/views/v1/ideas/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @ideas do |idea|
-  json.partial! 'idea', idea: idea
+  json.partial! 'idea', idea: idea, lite: params[:lite] == "true"
 end

--- a/web/app/views/v1/ideas/show.json.jbuilder
+++ b/web/app/views/v1/ideas/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'idea', idea: @idea
+json.partial! 'idea', idea: @idea, lite: params[:lite] == "true"

--- a/web/app/views/v1/jawns/index.json.jbuilder
+++ b/web/app/views/v1/jawns/index.json.jbuilder
@@ -1,30 +1,14 @@
-# if params[:lite] == "true"
-#   json.array! @jawns do |jawn|
-#     type = jawn.class.to_s.downcase
-#     
-#     case type
-#     when "spark"
-#       json.(jawn, :id, :created_at, :spark_type, :content_type, :content, :content_hash)
-#       json.file jawn.file.url if jawn.file.exists?
-#     when "idea"
-#       json.(jawn, :id, :description, :created_at)
-#     end
-#     
-#     json.jawn_type type
-#   end
-# else
-  lite = params[:lite] == "true"
+lite = params[:lite] == "true"
+
+json.array! @jawns do |jawn|
+  type = jawn.class.to_s.downcase
   
-  json.array! @jawns do |jawn|
-    type = jawn.class.to_s.downcase
-    
-    case type
-    when "spark"
-      json.partial! 'v1/sparks/spark', spark: jawn, lite: lite
-    when "idea"
-      json.partial! 'v1/ideas/idea', idea: jawn, lite: lite
-    end
-    
-    json.jawn_type type
+  case type
+  when "spark"
+    json.partial! 'v1/sparks/spark', spark: jawn, lite: lite
+  when "idea"
+    json.partial! 'v1/ideas/idea', idea: jawn, lite: lite
   end
-# end
+  
+  json.jawn_type type
+end

--- a/web/app/views/v1/jawns/index.json.jbuilder
+++ b/web/app/views/v1/jawns/index.json.jbuilder
@@ -1,28 +1,30 @@
-if params[:lite] == "true"
+# if params[:lite] == "true"
+#   json.array! @jawns do |jawn|
+#     type = jawn.class.to_s.downcase
+#     
+#     case type
+#     when "spark"
+#       json.(jawn, :id, :created_at, :spark_type, :content_type, :content, :content_hash)
+#       json.file jawn.file.url if jawn.file.exists?
+#     when "idea"
+#       json.(jawn, :id, :description, :created_at)
+#     end
+#     
+#     json.jawn_type type
+#   end
+# else
+  lite = params[:lite] == "true"
+  
   json.array! @jawns do |jawn|
     type = jawn.class.to_s.downcase
     
     case type
     when "spark"
-      json.(jawn, :id, :created_at, :spark_type, :content_type, :content, :content_hash)
-      json.file jawn.file.url if jawn.file.exists?
+      json.partial! 'v1/sparks/spark', spark: jawn, lite: lite
     when "idea"
-      json.(jawn, :id, :description, :created_at)
+      json.partial! 'v1/ideas/idea', idea: jawn, lite: lite
     end
     
     json.jawn_type type
   end
-else
-  json.array! @jawns do |jawn|
-    type = jawn.class.to_s.downcase
-    
-    case type
-    when "spark"
-      json.partial! 'v1/sparks/spark', spark: jawn
-    when "idea"
-      json.partial! 'v1/ideas/idea', idea: jawn
-    end
-    
-    json.jawn_type type
-  end
-end
+# end

--- a/web/app/views/v1/sparks/_spark.json.jbuilder
+++ b/web/app/views/v1/sparks/_spark.json.jbuilder
@@ -1,15 +1,16 @@
 json.(spark, :id, :created_at, :spark_type, :content_type, :content, :content_hash)
-
 json.file spark.file.url if spark.file.exists?
 
-json.users spark.users, :id, :name, :email
+unless lite
+  json.users spark.users, :id, :name, :email
 
-json.ideas spark.ideas, :id, :created_at, :description
+  json.ideas spark.ideas, :id, :created_at, :description
 
-json.comments spark.comments do |comment|
-  json.(comment, :id, :comment_text, :created_at)
-  json.user comment.user, :id, :name, :email
+  json.comments spark.comments do |comment|
+    json.(comment, :id, :comment_text, :created_at)
+    json.user comment.user, :id, :name, :email
+  end
+
+  tag_names = spark.tags.map(&:tag_text)
+  json.tags tag_names
 end
-
-tag_names = spark.tags.map(&:tag_text)
-json.tags tag_names

--- a/web/app/views/v1/sparks/index.json.jbuilder
+++ b/web/app/views/v1/sparks/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @sparks do |spark|
-  json.partial! 'spark', spark: spark
+  json.partial! 'spark', spark: spark, lite: params["lite"] == "true"
 end

--- a/web/app/views/v1/sparks/show.json.jbuilder
+++ b/web/app/views/v1/sparks/show.json.jbuilder
@@ -1,2 +1,2 @@
 json.spark_is_new true if @spark_is_new
-json.partial! 'spark', spark: @spark
+json.partial! 'spark', spark: @spark, lite: params["lite"] == "true"

--- a/web/spec/controllers/v1/comments_controller_spec.rb
+++ b/web/spec/controllers/v1/comments_controller_spec.rb
@@ -136,18 +136,18 @@ describe V1::CommentsController do
     describe "on a Spark" do
       
       it "is successful" do
-        post :create, :spark_id => @spark, :comment => @attr, :username => @test_user.name, :format => 'json', :token => @auth_token
+        post :create, :spark_id => @spark, :comment => @attr, :format => 'json', :token => @auth_token
         response.should be_success
       end
     
       it "should create the comment" do
         expect {
-          post :create, :spark_id => @spark, :comment => @attr, :username => @test_user.name, :format => 'json', :token => @auth_token
+          post :create, :spark_id => @spark, :comment => @attr, :format => 'json', :token => @auth_token
         }.to change { Comment.count }.by(1)
       end
       
       it "should return the comment" do
-        post :create, :spark_id => @spark, :comment => @attr, :username => @test_user.name, :format => 'json', :token => @auth_token
+        post :create, :spark_id => @spark, :comment => @attr, :format => 'json', :token => @auth_token
         output = JSON.parse(response.body)
 
         output.should be_a_kind_of(Hash)
@@ -155,13 +155,13 @@ describe V1::CommentsController do
       end
       
       it "should associate the user and the comment" do
-        post :create, :spark_id => @spark, :comment => @attr, :username => @test_user.name, :format => 'json', :token => @auth_token
+        post :create, :spark_id => @spark, :comment => @attr, :format => 'json', :token => @auth_token
         comment = Comment.last
         comment.user.should == @test_user
       end
       
       it "should associate the spark and the comment" do
-        post :create, :spark_id => @spark, :comment => @attr, :username => @test_user.name, :format => 'json', :token => @auth_token
+        post :create, :spark_id => @spark, :comment => @attr, :format => 'json', :token => @auth_token
         comment = Comment.find_by(comment_text: @attr[:comment_text])
         comment.commentable.should == @spark
       end
@@ -171,18 +171,18 @@ describe V1::CommentsController do
     describe "on an Idea" do
       
       it "is successful" do
-        post :create, :idea_id => @idea, :comment => @attr, :username => @test_user.name, :format => 'json', :token => @auth_token
+        post :create, :idea_id => @idea, :comment => @attr, :format => 'json', :token => @auth_token
         response.should be_success
       end
     
       it "should create the comment" do
         expect {
-          post :create, :idea_id => @idea, :comment => @attr, :username => @test_user.name, :format => 'json', :token => @auth_token
+          post :create, :idea_id => @idea, :comment => @attr, :format => 'json', :token => @auth_token
         }.to change { Comment.count }.by(1)
       end
       
       it "should return the comment" do
-        post :create, :idea_id => @idea, :comment => @attr, :username => @test_user.name, :format => 'json', :token => @auth_token
+        post :create, :idea_id => @idea, :comment => @attr, :format => 'json', :token => @auth_token
         output = JSON.parse(response.body)
 
         output.should be_a_kind_of(Hash)
@@ -190,13 +190,13 @@ describe V1::CommentsController do
       end
       
       it "should associate the user and the comment" do
-        post :create, :idea_id => @idea, :comment => @attr, :username => @test_user.name, :format => 'json', :token => @auth_token
+        post :create, :idea_id => @idea, :comment => @attr, :format => 'json', :token => @auth_token
         comment = Comment.last
         comment.user.should == @test_user
       end
       
       it "should associate the idea and the comment" do
-        post :create, :idea_id => @idea, :comment => @attr, :username => @test_user.name, :format => 'json', :token => @auth_token
+        post :create, :idea_id => @idea, :comment => @attr, :format => 'json', :token => @auth_token
         comment = Comment.last
         comment.commentable.should == @idea
       end
@@ -211,6 +211,9 @@ describe V1::CommentsController do
       @comment = FactoryGirl.create(:comment)
       @comment.user = @test_user
       @comment.save
+      
+      @wrong_user = FactoryGirl.create(:user)
+      @wrong_token = @wrong_user.devices.create(registration_id: "testid123").token
     end
     
     describe "on a Spark" do
@@ -223,13 +226,13 @@ describe V1::CommentsController do
       describe "with the correct user" do
         
         it "is successful" do
-          delete :destroy, :spark_id => @spark, :id => @comment, :username => @test_user.name, :format => 'json', :token => @auth_token
+          delete :destroy, :spark_id => @spark, :id => @comment, :format => 'json', :token => @auth_token
           response.should be_success
         end
 
         it "destroys the comment" do
           expect {
-            delete :destroy, :spark_id => @spark, :id => @comment, :username => @test_user.name, :format => 'json', :token => @auth_token
+            delete :destroy, :spark_id => @spark, :id => @comment, :format => 'json', :token => @auth_token
           }.to change { Comment.count }.by(-1)
         end
         
@@ -237,18 +240,14 @@ describe V1::CommentsController do
       
       describe "with the wrong user" do
         
-        before do
-          @wrong_user = FactoryGirl.create(:user)
-        end
-        
         it "isn't successful" do
-          delete :destroy, :spark_id => @spark, :id => @comment, :username => @wrong_user.name, :format => 'json', :token => @auth_token
+          delete :destroy, :spark_id => @spark, :id => @comment, :format => 'json', :token => @wrong_token
           response.should_not be_success
         end
 
         it "doesn't destroy the comment" do
           expect {
-            delete :destroy, :spark_id => @spark, :id => @comment, :username => @wrong_user.name, :format => 'json', :token => @auth_token
+            delete :destroy, :spark_id => @spark, :id => @comment, :format => 'json', :token => @wrong_token
           }.not_to change { Comment.count }
         end
         
@@ -266,13 +265,13 @@ describe V1::CommentsController do
       describe "with the correct user" do
         
         it "is successful" do
-          delete :destroy, :idea_id => @idea, :id => @comment, :username => @test_user.name, :format => 'json', :token => @auth_token
+          delete :destroy, :idea_id => @idea, :id => @comment, :format => 'json', :token => @auth_token
           response.should be_success
         end
 
         it "destroys the comment" do
           expect {
-            delete :destroy, :idea_id => @idea, :id => @comment, :username => @test_user.name, :format => 'json', :token => @auth_token
+            delete :destroy, :idea_id => @idea, :id => @comment, :format => 'json', :token => @auth_token
           }.to change { Comment.count }.by(-1)
         end
         
@@ -280,18 +279,14 @@ describe V1::CommentsController do
       
       describe "with the wrong user" do
         
-        before do
-          @wrong_user = FactoryGirl.create(:user)
-        end
-        
         it "isn't successful" do
-          delete :destroy, :idea_id => @idea, :id => @comment, :username => @wrong_user.name, :format => 'json', :token => @auth_token
+          delete :destroy, :idea_id => @idea, :id => @comment, :format => 'json', :token => @wrong_token
           response.should_not be_success
         end
 
         it "doesn't destroy the comment" do
           expect {
-            delete :destroy, :idea_id => @idea, :id => @comment, :username => @wrong_user.name, :format => 'json', :token => @auth_token
+            delete :destroy, :idea_id => @idea, :id => @comment, :format => 'json', :token => @wrong_token
           }.not_to change { Comment.count }
         end
         

--- a/web/spec/controllers/v1/ideas_controller_spec.rb
+++ b/web/spec/controllers/v1/ideas_controller_spec.rb
@@ -114,30 +114,30 @@ describe V1::IdeasController do
     describe "for a new valid idea" do
       
       it "is successful" do
-        post :create, :idea => @attr, :format => 'json', :username => @test_user.name, :sparks => @sparks, :token => @auth_token
+        post :create, :idea => @attr, :format => 'json', :sparks => @sparks, :token => @auth_token
         response.should be_success
       end
     
       it "should create the idea" do
         expect {
-          post :create, :idea => @attr, :format => 'json', :username => @test_user.name, :sparks => @sparks, :token => @auth_token
+          post :create, :idea => @attr, :format => 'json', :sparks => @sparks, :token => @auth_token
         }.to change { Idea.count }.by(1)
       end
       
       it "should add the user to the idea" do
-        post :create, :idea => @attr, :format => 'json', :username => @test_user.name, :sparks => @sparks, :token => @auth_token
+        post :create, :idea => @attr, :format => 'json', :sparks => @sparks, :token => @auth_token
         @idea = Idea.last
         @idea.user.should == @test_user
       end
       
       it "should add the sparks to the idea" do
-        post :create, :idea => @attr, :format => 'json', :username => @test_user.name, :sparks => @sparks, :token => @auth_token
+        post :create, :idea => @attr, :format => 'json', :sparks => @sparks, :token => @auth_token
         @idea = Idea.last
         @idea.sparks.should == [@s1, @s2]
       end
       
       it "should ignore invalid sparks" do
-        post :create, :idea => @attr, :format => 'json', :username => @test_user.name, :sparks => @sparks + ",100", :token => @auth_token
+        post :create, :idea => @attr, :format => 'json', :sparks => @sparks + ",100", :token => @auth_token
         @idea = Idea.last
         @idea.sparks.should == [@s1, @s2]
       end
@@ -149,7 +149,7 @@ describe V1::IdeasController do
         
         tags = [t1,t2,t3].map(&:tag_text).join(",")
         
-        post :create, :idea => @attr, :format => 'json', :username => @test_user.name, :sparks => @sparks, :tags => tags, :token => @auth_token
+        post :create, :idea => @attr, :format => 'json', :sparks => @sparks, :tags => tags, :token => @auth_token
         
         @idea = Idea.last
         @idea.tags.should == [t1,t2,t3]
@@ -162,7 +162,7 @@ describe V1::IdeasController do
         
         tags = [t1,t2,t3].join(",")
         
-        post :create, :idea => @attr, :format => 'json', :username => @test_user.name, :sparks => @sparks, :tags => tags, :token => @auth_token
+        post :create, :idea => @attr, :format => 'json', :sparks => @sparks, :tags => tags, :token => @auth_token
         
         [t1,t2,t3].each do |t|
           Tag.find_by(tag_text: t).should_not be_nil
@@ -170,7 +170,7 @@ describe V1::IdeasController do
       end
       
       it "should return the idea" do
-        post :create, :idea => @attr, :format => 'json', :username => @test_user.name, :sparks => @sparks, :token => @auth_token
+        post :create, :idea => @attr, :format => 'json', :sparks => @sparks, :token => @auth_token
         @idea = Idea.last
         output = JSON.parse(response.body)
 
@@ -183,13 +183,13 @@ describe V1::IdeasController do
     describe "for an idea without sparks" do
       
       it "isn't successful" do
-        post :create, :idea => @attr, :format => 'json', :username => @test_user.name, :token => @auth_token
+        post :create, :idea => @attr, :format => 'json', :token => @auth_token
         response.should_not be_success
       end
     
       it "shouldn't create the idea" do
         expect {
-          post :create, :idea => @attr, :format => 'json', :username => @test_user.name, :token => @auth_token
+          post :create, :idea => @attr, :format => 'json', :token => @auth_token
         }.not_to change { Idea.count }
       end
       
@@ -198,13 +198,13 @@ describe V1::IdeasController do
     describe "for an idea with invalid sparks" do
       
       it "isn't successful" do
-        post :create, :idea => @attr, :format => 'json', :username => @test_user.name, :sparks => "100,150", :token => @auth_token
+        post :create, :idea => @attr, :format => 'json', :sparks => "100,150", :token => @auth_token
         response.should_not be_success
       end
     
       it "shouldn't create the idea" do
         expect {
-          post :create, :idea => @attr, :format => 'json', :username => @test_user.name, :sparks => "100,150", :token => @auth_token
+          post :create, :idea => @attr, :format => 'json', :sparks => "100,150", :token => @auth_token
         }.not_to change { Idea.count }
       end
       
@@ -228,24 +228,24 @@ describe V1::IdeasController do
     end
     
     it "is successful" do
-      delete :destroy, :id => @idea, :format => 'json', :username => @test_user.name, :token => @auth_token
+      delete :destroy, :id => @idea, :format => 'json', :token => @auth_token
       response.should be_success
     end
     
     it "doesn't destroy the idea" do
       expect {
-        delete :destroy, :id => @idea, :format => 'json', :username => @test_user.name, :token => @auth_token
+        delete :destroy, :id => @idea, :format => 'json', :token => @auth_token
       }.not_to change { Idea.count }
     end
     
     it "removes the user from the idea" do
-      delete :destroy, :id => @idea, :format => 'json', :username => @test_user.name, :token => @auth_token
+      delete :destroy, :id => @idea, :format => 'json', :token => @auth_token
       @idea.reload
       @idea.user.should be_nil
     end
     
     it "returns the idea" do
-      delete :destroy, :id => @idea, :format => 'json', :username => @test_user.name, :token => @auth_token
+      delete :destroy, :id => @idea, :format => 'json', :token => @auth_token
       @idea.reload
       output = JSON.parse(response.body)
       

--- a/web/spec/controllers/v1/ideas_controller_spec.rb
+++ b/web/spec/controllers/v1/ideas_controller_spec.rb
@@ -43,6 +43,23 @@ describe V1::IdeasController do
       end
     end
     
+    describe "lite response" do
+      
+      it "only returns ids and stuff" do
+        get :index, :format => 'json', :lite => "true", :token => @auth_token
+        output = JSON.parse(response.body)
+        
+        output.should be_a_kind_of(Array)
+        
+        output.each do |idea|
+          idea["id"].should_not be_nil
+          idea["user"].should be_nil
+          idea["sparks"].should be_nil
+        end
+      end
+      
+    end
+    
   end
   
   describe "GET 'show'" do
@@ -62,6 +79,21 @@ describe V1::IdeasController do
       
       output.should be_a_kind_of(Hash)
       output["description"].should == @idea.description
+    end
+    
+    describe "lite response" do
+      
+      it "only returns id and stuff" do
+        get :show, :id => @idea, :format => 'json', :lite => "true", :token => @auth_token
+        output = JSON.parse(response.body)
+        
+        output.should be_a_kind_of(Hash)
+        
+        output["id"].should_not be_nil
+        output["user"].should be_nil
+        output["sparks"].should be_nil
+      end
+      
     end
     
   end

--- a/web/spec/controllers/v1/sparks_controller_spec.rb
+++ b/web/spec/controllers/v1/sparks_controller_spec.rb
@@ -43,6 +43,23 @@ describe V1::SparksController do
       end
     end
     
+    describe "lite response" do
+      
+      it "only returns ids and stuff" do
+        get :index, :format => 'json', :lite => "true", :token => @auth_token
+        output = JSON.parse(response.body)
+        
+        output.should be_a_kind_of(Array)
+        
+        output.each do |spark|
+          spark["id"].should_not be_nil
+          spark["users"].should be_nil
+          spark["ideas"].should be_nil
+        end
+      end
+      
+    end
+    
   end
   
   describe "GET 'show'" do
@@ -63,6 +80,21 @@ describe V1::SparksController do
       output.should be_a_kind_of(Hash)
       output["content_hash"].should == @spark.content_hash
       output["file"].should_not be_nil
+    end
+    
+    describe "lite response" do
+      
+      it "only returns id and stuff" do
+        get :show, :id => @spark, :format => 'json', :lite => "true", :token => @auth_token
+        output = JSON.parse(response.body)
+        
+        output.should be_a_kind_of(Hash)
+        
+        output["id"].should_not be_nil
+        output["users"].should be_nil
+        output["ideas"].should be_nil
+      end
+      
     end
     
   end

--- a/web/spec/controllers/v1/sparks_controller_spec.rb
+++ b/web/spec/controllers/v1/sparks_controller_spec.rb
@@ -113,20 +113,20 @@ describe V1::SparksController do
     describe "for a new valid spark" do
       
       it "is successful" do
-        post :create, :spark => @attr, :format => 'json', :username => @test_user.name, :token => @auth_token
+        post :create, :spark => @attr, :format => 'json', :token => @auth_token
         response.should be_success
       end
     
       it "should create the spark" do
         expect {
-          post :create, :spark => @attr, :format => 'json', :username => @test_user.name, :token => @auth_token
+          post :create, :spark => @attr, :format => 'json', :token => @auth_token
         }.to change { Spark.count }.by(1)
         
         Spark.last.content.should == @attr[:content]
       end
       
       it "should add the user to the spark" do
-        post :create, :spark => @attr, :format => 'json', :username => @test_user.name, :token => @auth_token
+        post :create, :spark => @attr, :format => 'json', :token => @auth_token
         Spark.last.users.should == [@test_user]
       end
       
@@ -137,7 +137,7 @@ describe V1::SparksController do
         
         tags = [t1,t2,t3].map(&:tag_text).join(",")
         
-        post :create, :spark => @attr, :format => 'json', :username => @test_user.name, :tags => tags, :token => @auth_token
+        post :create, :spark => @attr, :format => 'json', :tags => tags, :token => @auth_token
         
         Spark.last.tags.should == [t1,t2,t3]
       end
@@ -149,7 +149,7 @@ describe V1::SparksController do
         
         tags = [t1,t2,t3].join(",")
         
-        post :create, :spark => @attr, :format => 'json', :username => @test_user.name, :tags => tags, :token => @auth_token
+        post :create, :spark => @attr, :format => 'json', :tags => tags, :token => @auth_token
         
         [t1,t2,t3].each do |t|
           Tag.find_by(tag_text: t).should_not be_nil
@@ -157,7 +157,7 @@ describe V1::SparksController do
       end
       
       it "should return the spark" do
-        post :create, :spark => @attr, :format => 'json', :username => @test_user.name, :token => @auth_token
+        post :create, :spark => @attr, :format => 'json', :token => @auth_token
         output = JSON.parse(response.body)
 
         output.should be_a_kind_of(Hash)
@@ -175,13 +175,13 @@ describe V1::SparksController do
       end
       
       it "isn't successful" do
-        post :create, :spark => @attr, :format => 'json', :username => @test_user.name, :token => @auth_token
+        post :create, :spark => @attr, :format => 'json', :token => @auth_token
         response.should_not be_success
       end
     
       it "shouldn't create the spark" do
         expect {
-          post :create, :spark => @attr, :format => 'json', :username => @test_user.name, :token => @auth_token
+          post :create, :spark => @attr, :format => 'json', :token => @auth_token
         }.not_to change { Spark.count }
       end
       
@@ -198,23 +198,23 @@ describe V1::SparksController do
       end
       
       it "is successful" do
-        post :create, :spark => @attr, :format => 'json', :username => @user2.name, :token => @auth_token
+        post :create, :spark => @attr, :format => 'json', :token => @auth_token
         response.should be_success
       end
     
       it "shouldn't create the spark" do
         expect {
-          post :create, :spark => @attr, :format => 'json', :username => @user2.name, :token => @auth_token
+          post :create, :spark => @attr, :format => 'json', :token => @auth_token
         }.not_to change { Spark.count }
       end
       
       it "should add the user to the spark" do
-        post :create, :spark => @attr, :format => 'json', :username => @user2.name, :token => @auth_token
+        post :create, :spark => @attr, :format => 'json', :token => @auth_token
         @spark.users.should == [@test_user, @user2]
       end
       
       it "should return the spark" do
-        post :create, :spark => @attr, :format => 'json', :username => @user2.name, :token => @auth_token
+        post :create, :spark => @attr, :format => 'json', :token => @auth_token
         output = JSON.parse(response.body)
 
         output.should be_a_kind_of(Hash)
@@ -235,23 +235,23 @@ describe V1::SparksController do
     end
     
     it "is successful" do
-      delete :destroy, :id => @spark, :format => 'json', :username => @test_user.name, :token => @auth_token
+      delete :destroy, :id => @spark, :format => 'json', :token => @auth_token
       response.should be_success
     end
     
     it "doesn't destroy the spark" do
       expect {
-        delete :destroy, :id => @spark, :format => 'json', :username => @test_user.name, :token => @auth_token
+        delete :destroy, :id => @spark, :format => 'json', :token => @auth_token
       }.not_to change { Spark.count }
     end
     
     it "removes the user from the spark" do
-      delete :destroy, :id => @spark, :format => 'json', :username => @test_user.name, :token => @auth_token
+      delete :destroy, :id => @spark, :format => 'json', :token => @auth_token
       @spark.users.include?(@test_user).should_not be_true
     end
     
     it "returns the spark" do
-      delete :destroy, :id => @spark, :format => 'json', :username => @test_user.name, :token => @auth_token
+      delete :destroy, :id => @spark, :format => 'json', :token => @auth_token
       @spark.reload
       output = JSON.parse(response.body)
 


### PR DESCRIPTION
Replaces authentication with the "username" parameter with authentication by tokens.
