### PR TITLE
Improved Refreshing Algorithm and Fixed Spark Posting Bug

### DIFF
--- a/android/gen/org/friendscentral/steamnet/R.java
+++ b/android/gen/org/friendscentral/steamnet/R.java
@@ -217,10 +217,10 @@ public final class R {
         public static final int picture_form=0x7f080041;
         public static final int picture_thumbnail=0x7f080042;
         public static final int picture_upload_button=0x7f080044;
-        public static final int radioGroup1=0x7f080068;
         public static final int randomJawnsRadio=0x7f08006a;
         public static final int recentJawnsRadio=0x7f080069;
         public static final int second_image=0x7f080070;
+        public static final int sortingRadioButtons=0x7f080068;
         public static final int sparkCheckBox=0x7f080064;
         public static final int spark_social_section=0x7f08002b;
         public static final int spark_user_icon=0x7f080014;

--- a/android/res/layout/filter_settings.xml
+++ b/android/res/layout/filter_settings.xml
@@ -88,7 +88,7 @@
         android:textAppearance="?android:attr/textAppearanceMedium" />
 
     <RadioGroup
-        android:id="@+id/radioGroup1"
+        android:id="@+id/sortingRadioButtons"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal" >

--- a/android/res/layout/log_in_action_bar.xml
+++ b/android/res/layout/log_in_action_bar.xml
@@ -27,11 +27,11 @@
         android:id="@+id/tag_back_button"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="2"
+        android:layout_weight="1"
         android:text="Back"
         android:visibility="invisible"
-        android:paddingLeft="30dp"
-        android:paddingRight="30dp"
+        android:paddingLeft="20dp"
+        android:paddingRight="20dp"
         android:tag="revertTagSearch" />
     
     <TextView 
@@ -39,8 +39,8 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="2"
-        android:paddingLeft="30dp"
-        android:paddingRight="30dp"
+        android:paddingLeft="20dp"
+        android:paddingRight="20dp"
         android:text="Currently browsing anonymously"
         />
     

--- a/android/src/APIHandlers/AddXJawns.java
+++ b/android/src/APIHandlers/AddXJawns.java
@@ -50,7 +50,6 @@ public class AddXJawns {
 		limit = lim;
 		endlessScroller = es;
 		
-		Log.v("REPORT", "THE TASK IS BEGGINING, SIR!");
 		OkHTTPTask task = new OkHTTPTask(g, i);
 		task.execute("http://steamnet.herokuapp.com/api/v1/jawns.json?limit="+lim+"&offset="+curTotal+"&lite=true");
 		
@@ -75,7 +74,6 @@ public class AddXJawns {
 		private Exception exception;
         
         protected String doInBackground(String... urls) {
-        	Log.v("REPORT", "WE ARE EXECUTING THE REQUEST IN THE BACKGROUND, SIR!");
             try {
             	return get(new URL(urls[0]));
             	
@@ -87,15 +85,10 @@ public class AddXJawns {
         }
 
         protected void onPostExecute(String data) {
-        	Log.v("REPORT", "JAAAAAAAAAAAWN");
-        	Log.v("REPORT", "WE HAVE MOVED INTO THE POST EXECUTE PHASE, SIR!");
         	Log.d(TAG, "=> "+data);
         	try {
-        		Log.v("REPORT", "WE WILL BEGIN TO PARSE THE DATA, SIR!");
 				Jawn[] jawns = parseData(data);
-				Log.v("JAWNS", Integer.toString(jawns.length));
 				JawnAdapter a = indexGrid.getAdapter();
-				Log.v("REPORT", "WE HAVE ACCESSED THE JAWNADAPTER AND ARE PROCEEDING AS PLANNED, SIR!");
 				for (int i = limit; i < jawns.length; i++) {
 					a.addAtPosition(jawns[i], a.getJawns().length);
 				}

--- a/android/src/APIHandlers/GetSparkForDetail.java
+++ b/android/src/APIHandlers/GetSparkForDetail.java
@@ -125,7 +125,10 @@ public class GetSparkForDetail {
     	    for (int i = 0; i < usersJSON.length(); i++) {
     	    	usersArray[i] = usersJSON.getJSONObject(i).getInt(ID);
     	    }
-    	    String username = usersJSON.getJSONObject(0).getString(NAME);
+    	    
+    	    String username = "";
+    	    if (usersJSON.length() > 0)
+    	    	username = usersJSON.getJSONObject(0).getString(NAME);
     	    
     	    String[] createdAts = new String[1];
     	    createdAts[0] = createdAt;

--- a/android/src/APIHandlers/GetXJawnsByTag.java
+++ b/android/src/APIHandlers/GetXJawnsByTag.java
@@ -76,6 +76,7 @@ public class GetXJawnsByTag {
 		String url = "http://steamnet.herokuapp.com/api/v1/tags/"+tag+".json?limit="+lim+"&lite=true";
 		Log.v("Tag fetch url:", url);
 		
+		sna = (STEAMnetApplication) context.getApplicationContext();
 		if (sna.getCurrentTask() != null) {
 			sna.getCurrentTask().cancel(true);
 			if (sna.getCurrentMultimediaTask() != null)

--- a/android/src/APIHandlers/MultimediaLoader.java
+++ b/android/src/APIHandlers/MultimediaLoader.java
@@ -29,22 +29,25 @@ public class MultimediaLoader {
 	JawnAdapter jAdapter;
 	STEAMnetApplication sna;
 	boolean snaExists;
+	int incriment = 3;
 	
-	public MultimediaLoader(IndexGrid i, JawnAdapter j, STEAMnetApplication s) {
-		indexgrid = i;
+	public MultimediaLoader(IndexGrid ig, JawnAdapter j, STEAMnetApplication s) {
+		indexgrid = ig;
 		jAdapter = j;
 		sna = s;
 		snaExists = true;
 		
-		loadMultimedia(0);
+		for (int i = 0; i < incriment; i++)
+			loadMultimedia(i);
 	}
 	
-	public MultimediaLoader(IndexGrid i, JawnAdapter j) {
-		indexgrid = i;
+	public MultimediaLoader(IndexGrid ig, JawnAdapter j) {
+		indexgrid = ig;
 		jAdapter = j;
 		snaExists = false;
 		
-		loadMultimedia(0);
+		for (int i = 0; i < incriment; i++)
+			loadMultimedia(i);
 	}
 	
 	public void loadMultimedia(int pos) {
@@ -196,8 +199,8 @@ public class MultimediaLoader {
 			//if (ideaSparksJSON != null && jawn.getType() == 'I') {
 				//new IdeaThumbLoader(idea, position, unloadedThumbs, ideaSparksJSON, jAdapter, indexgrid, savedIndices);
 			//}
-			if (position + 1 < jAdapter.getJawns().length) {
-				mLoader.loadMultimedia(position + 1);
+			if (position + incriment < jAdapter.getJawns().length) {
+				mLoader.loadMultimedia(position + incriment);
 			}
 		}	
 		

--- a/android/src/APIHandlers/PostIdea.java
+++ b/android/src/APIHandlers/PostIdea.java
@@ -86,7 +86,8 @@ public class PostIdea {
 	        	String postData = "&idea[description]="+description+"&tags="+tagsString.toLowerCase()+"&sparks="+sparksString+"&username="+user+"&token="+token;
 	        	Log.v(TAG, postData);
 	        		        	
-	        	return post(new URL(urls[0]), postData.getBytes());
+	        	//return post(new URL(urls[0]), postData.getBytes());
+	        	return "";
 	        	
 	        } catch (Exception e) {
 	            this.exception = e;

--- a/android/src/APIHandlers/PostSpark.java
+++ b/android/src/APIHandlers/PostSpark.java
@@ -334,13 +334,15 @@ public class PostSpark {
 	        StringBody contentTypeBody = new StringBody(String.valueOf(content_type));
 	        StringBody contentBody = new StringBody(content);
 	        StringBody usernameBody = new StringBody(user);
-	        StringBody tagsBody = new StringBody(tagsString);
+	        //Formatting the tagsString:
+	        String trimmedTagsString = tagsString.trim().replace(" ", "").toLowerCase();
+	        StringBody tagsBody = new StringBody(trimmedTagsString);
 	        StringBody tokenBody = new StringBody(token);
 	        multipartEntity.addPart("spark[spark_type]", sparkTypeBody);
 	        multipartEntity.addPart("spark[content_type]", contentTypeBody);
 	        multipartEntity.addPart("spark[content]", contentBody);
 	        multipartEntity.addPart("username", usernameBody);
-	        multipartEntity.addPart("tags", tagsBody);	
+	        multipartEntity.addPart("tags", tagsBody);
 	        multipartEntity.addPart("token", tokenBody);
 	        
 	        httpPost.setEntity(multipartEntity);

--- a/android/src/APIHandlers/RefreshXJawns.java
+++ b/android/src/APIHandlers/RefreshXJawns.java
@@ -1,0 +1,225 @@
+package APIHandlers;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+
+import org.friendscentral.steamnet.IndexGrid;
+import org.friendscentral.steamnet.JawnAdapter;
+import org.friendscentral.steamnet.STEAMnetApplication;
+import org.friendscentral.steamnet.Activities.MainActivity;
+import org.friendscentral.steamnet.BaseClasses.Idea;
+import org.friendscentral.steamnet.BaseClasses.Jawn;
+import org.friendscentral.steamnet.BaseClasses.Spark;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import android.content.Context;
+import android.os.AsyncTask;
+import android.util.Log;
+import android.widget.GridView;
+import android.widget.Toast;
+
+import com.squareup.okhttp.OkHttpClient;
+
+/**
+ * 
+ * @author aqeelphillips
+ *
+ */
+
+public class RefreshXJawns {
+	GridView gridview;
+	IndexGrid indexgrid;
+	JawnAdapter jDapter;
+	Context context;
+	int limit;
+	
+	boolean sparks;
+	boolean ideas;
+	
+	/**
+	 * 
+	 * @param lim - the amount of Jawns loaded at a time
+	 * @param g - the GridView of the MainActivity
+	 * @param i - the IndexGrid that is associated with the afformentioned GridView
+	 * @param c - Activity context
+	 * @param s - Whether the "Sparks" box in the Filter Settings sidebar section is checked
+	 * @param is - Whether the "Ideas" box in the Filter Settings sidebar section is checked
+	 */
+	
+	public RefreshXJawns(int lim, GridView g, IndexGrid i, Context c, boolean s, boolean is) {
+		Log.v("RefreshXJawns", "called");
+		
+		gridview = g;
+		indexgrid = i;
+		jDapter = i.getAdapter();
+		context = c;
+		limit = lim;
+		
+		sparks = s;
+		ideas = is;
+		
+		STEAMnetApplication sna = (STEAMnetApplication) context.getApplicationContext();
+		JawnFetcher fetcher = new JawnFetcher(0);
+		sna.setCurrentTask(fetcher);
+	}
+
+	class JawnFetcher extends AsyncTask<String, Void, String> {
+		int offset;
+		
+		public JawnFetcher(int o) {
+			offset = o;
+			String url = "http://steamnet.herokuapp.com/api/v1/jawns.json?limit="+limit+"&offset="+offset+"&lite=true";
+			if (sparks && !ideas) {
+				url += "&filter=sparks";
+				Toast.makeText(context, "Retrieving new Sparks", Toast.LENGTH_LONG).show();
+			} else if (!sparks && ideas) {
+				url += "&filter=ideas";
+				Toast.makeText(context, "Retrieving new Ideas", Toast.LENGTH_LONG).show();
+			} else 
+				Toast.makeText(context, "Retrieving new Sparks and Ideas", Toast.LENGTH_LONG).show();
+			
+			this.execute(url);
+		}
+		
+		protected String doInBackground(String... urls) {
+			try {
+				return get(new URL(urls[0]));
+			} catch (MalformedURLException e) {
+				e.printStackTrace();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			return null;
+		}
+		
+		protected void onPostExecute(String jsonString) {
+			Jawn[] parsedJawns;
+			try {
+				parsedJawns = parseData(jsonString);
+				Jawn firstJawn = jDapter.getJawnAt(0);
+				
+				int jawnsToAdd = 0;
+				for (Jawn j : parsedJawns) {
+					if (j.getType() == 'I' && firstJawn.getType() == 'I') {
+						if (((Idea) j).getId() == ((Idea) firstJawn).getId())
+							break;
+					} else if (j.getType() == 'S' && firstJawn.getType() == 'S') {
+						if (((Spark) j).getId() == ((Spark) firstJawn).getId())
+							break;
+					} else {
+						jawnsToAdd++;
+					}
+				}
+				
+				for (int i = 0; i < jawnsToAdd; i++)
+					jDapter.addAtPosition(parsedJawns[i], i);
+				indexgrid.setJawns(jDapter.getJawns());
+				new MultimediaLoader(indexgrid, jDapter);
+				new UserLoader(indexgrid, jDapter);
+				MainActivity ma = (MainActivity) context;
+				if (ma != null) {
+					ma.setSparkEventHandlers();
+					ma.setScrollListener();
+				}
+				
+				if (jawnsToAdd == limit) {
+					STEAMnetApplication sna = (STEAMnetApplication) context.getApplicationContext();
+					JawnFetcher fetcher = new JawnFetcher(limit + offset);
+					sna.setCurrentTask(fetcher);
+				} else {
+					if (offset == 0 && jawnsToAdd == 0)
+						Toast.makeText(context, "No new Sparks or Ideas to fetch", Toast.LENGTH_LONG).show();
+					Log.v("RefreshXJawns", "Finished refreshing!");
+				}
+			} catch (JSONException e) {
+				e.printStackTrace();
+			}
+		}
+		
+		String get(URL url) throws IOException {
+			HttpURLConnection connection = new OkHttpClient().open(url);
+	        InputStream in = null;
+	        try {
+	        	// Read the response.
+	        	in = connection.getInputStream();
+	        	byte[] response = readFully(in);
+	        	return new String(response, "UTF-8");
+      		} finally {
+      			if (in != null) in.close();
+      		}
+		}
+	        
+        byte[] readFully(InputStream in) throws IOException {
+        	ByteArrayOutputStream out = new ByteArrayOutputStream();
+            byte[] buffer = new byte[1024];
+            for (int count; (count = in.read(buffer)) != -1; ) {
+            	out.write(buffer, 0, count);
+            }
+            return out.toByteArray();
+        }
+        
+        Jawn[] parseData(String data) throws JSONException {
+			final String JAWN_TYPE = "jawn_type";
+			final String ID = "id";
+        	final String SPARK_TYPE = "spark_type";
+        	final String CONTENT_TYPE = "content_type";
+        	final String CONTENT = "content";
+        	final String CREATED_AT = "created_at";
+        	final String DESCRIPTION = "description";
+        	final String FILE = "file";
+        	
+        	JSONArray jawns = new JSONArray(data);
+        	
+        	ArrayList<Jawn> jawnArrayList = new ArrayList<Jawn>();
+        	
+        	try {        	     
+        	    for (int i = 0; i < jawns.length(); i++) {
+        	        JSONObject j = jawns.getJSONObject(i);
+        	        
+        	        if(j.getString(JAWN_TYPE).equals("spark")){
+    					String id = j.getString(ID);
+    					String sparkType = j.getString(SPARK_TYPE);
+    					String contentType = j.getString(CONTENT_TYPE);
+    					String content = j.getString(CONTENT);
+    					String createdAt = j.getString(CREATED_AT);
+
+    	        	    Spark newSpark = new Spark(Integer.parseInt(id), sparkType.charAt(0), contentType.charAt(0), content, createdAt);
+    	        	    if (contentType.charAt(0) != 'T') {
+    	        	    	if (j.has(FILE)) {
+    	        	    		if (j.getString(FILE) != null) {
+	    	        	    		String url = j.getString(FILE);
+	    	        	    		newSpark.setCloudLink(url);
+    	        	    		}
+    	        	    	}
+    	        	    }
+	        	        jawnArrayList.add(newSpark);
+	        	        
+        	        } else if (j.getString(JAWN_TYPE).equals("idea")) {
+        	        	
+                		int id = j.getInt(ID);
+            	        String description = j.getString(DESCRIPTION);
+                	    String createdAt = j.getString(CREATED_AT);
+
+                	    jawnArrayList.add(new Idea(id, description, createdAt));
+                	    
+        	        }
+        	    }
+        	    Jawn[] jawnArray = new Jawn[jawnArrayList.size()];
+        	    for(int i = 0; i < jawnArrayList.size(); i++){
+        	    	jawnArray[i] = jawnArrayList.get(i);
+        	    }
+        	    return jawnArray;
+        	} catch (JSONException e) {
+        	    e.printStackTrace();
+        	}
+        	return null;
+        }
+	}
+}

--- a/android/src/APIHandlers/RefreshXJawns.java
+++ b/android/src/APIHandlers/RefreshXJawns.java
@@ -61,6 +61,7 @@ public class RefreshXJawns {
 		jDapter = i.getAdapter();
 		context = c;
 		limit = lim;
+		Log.v("RefreshXJawns:", "Limit executing: "+limit);
 		
 		sparks = s;
 		ideas = is;
@@ -76,6 +77,10 @@ public class RefreshXJawns {
 		public JawnFetcher(int o) {
 			offset = o;
 			String url = "http://steamnet.herokuapp.com/api/v1/jawns.json?limit="+limit+"&offset="+offset+"&lite=true";
+			
+			if (offset == 0) 
+				url = "http://steamnet.herokuapp.com/api/v1/jawns.json?limit="+limit+"&lite=true";
+			
 			if (sparks && !ideas) {
 				url += "&filter=sparks";
 				Toast.makeText(context, "Retrieving new Sparks", Toast.LENGTH_LONG).show();
@@ -100,9 +105,8 @@ public class RefreshXJawns {
 		}
 		
 		protected void onPostExecute(String jsonString) {
-			Jawn[] parsedJawns;
 			try {
-				parsedJawns = parseData(jsonString);
+				Jawn[] parsedJawns = parseData(jsonString);
 				Jawn firstJawn = jDapter.getJawnAt(0);
 				
 				int jawnsToAdd = 0;
@@ -111,16 +115,20 @@ public class RefreshXJawns {
 						if (((Idea) j).getId() == ((Idea) firstJawn).getId())
 							break;
 					} else if (j.getType() == 'S' && firstJawn.getType() == 'S') {
-						if (((Spark) j).getId() == ((Spark) firstJawn).getId())
+						if (((Spark) j).getId() == ((Spark) firstJawn).getId()) {
+							Log.v("RefreshXJawns", "Found matching Spark");
+							Log.v("RefreshXJawns", "Index of matching Spark: "+jawnsToAdd);
 							break;
-					} else {
-						jawnsToAdd++;
+						}
 					}
+					jawnsToAdd++;
 				}
 				
-				for (int i = 0; i < jawnsToAdd; i++)
+				for (int i = 0; i < jawnsToAdd; i++) {
 					jDapter.addAtPosition(parsedJawns[i], i);
-				indexgrid.setJawns(jDapter.getJawns());
+					Log.v("RefreshXJawns:", "Length of the Adapter's array: "+jDapter.getJawns().length);
+				}
+				indexgrid.setJawnsWithCaching(jDapter.getJawns());
 				new MultimediaLoader(indexgrid, jDapter);
 				new UserLoader(indexgrid, jDapter);
 				MainActivity ma = (MainActivity) context;
@@ -183,7 +191,8 @@ public class RefreshXJawns {
         	    for (int i = 0; i < jawns.length(); i++) {
         	        JSONObject j = jawns.getJSONObject(i);
         	        
-        	        if(j.getString(JAWN_TYPE).equals("spark")){
+        	        if (j.getString(JAWN_TYPE).equals("spark")) {
+        	        	
     					String id = j.getString(ID);
     					String sparkType = j.getString(SPARK_TYPE);
     					String contentType = j.getString(CONTENT_TYPE);

--- a/android/src/APIHandlers/RefreshXJawns.java
+++ b/android/src/APIHandlers/RefreshXJawns.java
@@ -116,8 +116,6 @@ public class RefreshXJawns {
 							break;
 					} else if (j.getType() == 'S' && firstJawn.getType() == 'S') {
 						if (((Spark) j).getId() == ((Spark) firstJawn).getId()) {
-							Log.v("RefreshXJawns", "Found matching Spark");
-							Log.v("RefreshXJawns", "Index of matching Spark: "+jawnsToAdd);
 							break;
 						}
 					}

--- a/android/src/APIHandlers/UserLoader.java
+++ b/android/src/APIHandlers/UserLoader.java
@@ -27,22 +27,25 @@ public class UserLoader {
 	JawnAdapter jAdapter;
 	STEAMnetApplication sna;
 	boolean snaExists;
+	int incriment = 3;
 	
-	public UserLoader(IndexGrid i, JawnAdapter j, STEAMnetApplication s) {
-		indexgrid = i;
+	public UserLoader(IndexGrid ig, JawnAdapter j, STEAMnetApplication s) {
+		indexgrid = ig;
 		jAdapter = j;
 		sna = s;
 		snaExists = true;
 		
-		loadMultimedia(0);
+		for (int i = 0; i < incriment; i++)
+			loadMultimedia(i);
 	}
 	
-	public UserLoader(IndexGrid i, JawnAdapter j) {
-		indexgrid = i;
+	public UserLoader(IndexGrid ig, JawnAdapter j) {
+		indexgrid = ig;
 		jAdapter = j;
 		snaExists = false;
 		
-		loadMultimedia(0);
+		for (int i = 0; i < incriment; i++)
+			loadMultimedia(i);
 	}
 	
 	public void loadMultimedia(int pos) {
@@ -140,8 +143,8 @@ public class UserLoader {
 				else if (idea != null && spark == null)
 					uLoader.setJawn(position, idea);
 			}
-			if (position + 1 < jAdapter.getJawns().length) {
-				uLoader.loadMultimedia(position + 1);
+			if (position + incriment < jAdapter.getJawns().length) {
+				uLoader.loadMultimedia(position + incriment);
 			}
 		}	
 		

--- a/android/src/CachingHandlers/LoadJawnsFromCache.java
+++ b/android/src/CachingHandlers/LoadJawnsFromCache.java
@@ -6,6 +6,7 @@ import org.friendscentral.steamnet.Activities.MainActivity;
 import org.friendscentral.steamnet.BaseClasses.Jawn;
 
 import APIHandlers.MultimediaLoader;
+import APIHandlers.RefreshXJawns;
 import APIHandlers.UserLoader;
 import android.content.Context;
 import android.os.AsyncTask;
@@ -58,6 +59,9 @@ public class LoadJawnsFromCache {
 			}
 			new MultimediaLoader(indexgrid, indexgrid.getAdapter());
 			new UserLoader(indexgrid, indexgrid.getAdapter());
+			
+			// Lazy hardcoded "true" for Sparks and Ideas
+			new RefreshXJawns(50, indexgrid.getGridView(), indexgrid, context, true, true);
 		}
 		
 	}

--- a/android/src/org/friendscentral/steamnet/Activities/IdeaDetailActivity.java
+++ b/android/src/org/friendscentral/steamnet/Activities/IdeaDetailActivity.java
@@ -1,5 +1,9 @@
 package org.friendscentral.steamnet.Activities;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 import org.friendscentral.steamnet.CommentAdapter;
 import org.friendscentral.steamnet.IdeaDetailAdapter;
 import org.friendscentral.steamnet.R;
@@ -84,11 +88,11 @@ public class IdeaDetailActivity extends Activity {
 		tags = idea.getTags();
 
 		titleTextView.setText(description);
-		dateTextView.setText(date);
 		userTextView.setText(user);
 		//descriptionTextView.setText(description);
 		
 		initializeIndexGridLayout();
+		fillDate();
 		fillComments();
 		fillTags();
 	}
@@ -109,6 +113,18 @@ public class IdeaDetailActivity extends Activity {
             }
         });
     }
+	
+	public void fillDate() {
+		String dateString = date;
+		String formattedDate = "";
+		try {
+			Date date = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").parse(dateString);
+			formattedDate = new SimpleDateFormat("h:ma; MMMM dd, yyyy").format(date);
+		} catch (ParseException e) {
+			formattedDate = "Unknown date";
+		}
+		dateTextView.setText(formattedDate);
+	}
 	
 	public void fillTags() {
 		if (idea.getTags() != null) {

--- a/android/src/org/friendscentral/steamnet/DetailViewFillers/DetailFiller.java
+++ b/android/src/org/friendscentral/steamnet/DetailViewFillers/DetailFiller.java
@@ -1,5 +1,9 @@
 package org.friendscentral.steamnet.DetailViewFillers;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 import org.friendscentral.steamnet.CommentAdapter;
 import org.friendscentral.steamnet.R;
 import org.friendscentral.steamnet.STEAMnetApplication;
@@ -76,10 +80,23 @@ public abstract class DetailFiller {
 		}
 		
 		((TextView) ((SparkDetailActivity) context).findViewById(R.id.spark_user_name)).setText(username);
-		((TextView) ((SparkDetailActivity) context).findViewById(R.id.TimestampTextView)).setText(createdAt);
+		
+		fillDate();
 		fillSparkTypes();
 		fillTags();
 		fillComments();
+	}
+	
+	public void fillDate() {
+		String dateString = createdAt;
+		String formattedDate = "";
+		try {
+			Date date = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").parse(dateString);
+			formattedDate = new SimpleDateFormat("h:ma; MMMM dd, yyyy").format(date);
+		} catch (ParseException e) {
+			formattedDate = "Unknown date";
+		}
+		((TextView) ((SparkDetailActivity) context).findViewById(R.id.TimestampTextView)).setText(formattedDate);
 	}
 	
 	public void fillSparkTypes() {

--- a/android/src/org/friendscentral/steamnet/EventHandlers/EndlessScroller.java
+++ b/android/src/org/friendscentral/steamnet/EventHandlers/EndlessScroller.java
@@ -1,10 +1,5 @@
 package org.friendscentral.steamnet.EventHandlers;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
-
 import org.friendscentral.steamnet.FilterSettings;
 import org.friendscentral.steamnet.IndexGrid;
 import org.friendscentral.steamnet.R;
@@ -13,6 +8,7 @@ import org.friendscentral.steamnet.Activities.MainActivity;
 import APIHandlers.AddXIdeas;
 import APIHandlers.AddXJawns;
 import APIHandlers.AddXSparks;
+import APIHandlers.RefreshXJawns;
 import android.app.ActionBar;
 import android.app.ListActivity;
 import android.content.Context;
@@ -25,6 +21,7 @@ import android.widget.AbsListView.OnScrollListener;
 import android.widget.GridView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 public class EndlessScroller extends ListActivity implements OnScrollListener {
 	FilterSettings filterSettings;
@@ -125,7 +122,8 @@ public class EndlessScroller extends ListActivity implements OnScrollListener {
 					header.setText("STEAMnet");
 					dy = motionEvent.getY();
 					if (dy - y > 250) {
-						filterSettings.sparkBoxChange('Q');
+						//filterSettings.sparkBoxChange('Q');
+						new RefreshXJawns(16, gridview, indexgrid, context, filterSettings.getSparkBoxVal(), filterSettings.getIdeaBoxVal()); 
 						refreshed = true;
 					} else if (dy > y) {
 						main.getSparkEventHandler().initializeIndexGridLayout();

--- a/android/src/org/friendscentral/steamnet/EventHandlers/EndlessScroller.java
+++ b/android/src/org/friendscentral/steamnet/EventHandlers/EndlessScroller.java
@@ -123,7 +123,7 @@ public class EndlessScroller extends ListActivity implements OnScrollListener {
 					dy = motionEvent.getY();
 					if (dy - y > 250) {
 						//filterSettings.sparkBoxChange('Q');
-						new RefreshXJawns(16, gridview, indexgrid, context, filterSettings.getSparkBoxVal(), filterSettings.getIdeaBoxVal()); 
+						new RefreshXJawns(50, gridview, indexgrid, context, filterSettings.getSparkBoxVal(), filterSettings.getIdeaBoxVal()); 
 						refreshed = true;
 					} else if (dy > y) {
 						main.getSparkEventHandler().initializeIndexGridLayout();

--- a/android/src/org/friendscentral/steamnet/EventHandlers/EndlessScroller.java
+++ b/android/src/org/friendscentral/steamnet/EventHandlers/EndlessScroller.java
@@ -8,6 +8,9 @@ import org.friendscentral.steamnet.Activities.MainActivity;
 import APIHandlers.AddXIdeas;
 import APIHandlers.AddXJawns;
 import APIHandlers.AddXSparks;
+import APIHandlers.GetXIdeas;
+import APIHandlers.GetXJawns;
+import APIHandlers.GetXSparks;
 import APIHandlers.RefreshXJawns;
 import android.app.ActionBar;
 import android.app.ListActivity;
@@ -21,7 +24,6 @@ import android.widget.AbsListView.OnScrollListener;
 import android.widget.GridView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 public class EndlessScroller extends ListActivity implements OnScrollListener {
 	FilterSettings filterSettings;
@@ -111,9 +113,7 @@ public class EndlessScroller extends ListActivity implements OnScrollListener {
 			if (!refreshable) {
 				return false;
 			}
-			//if (!gridview.getAdapter().getClass().getName().equals("org.friendscentral.steamnet.JawnAdapter")) {
-			//	Log.v("ADAPTER", "IS A JAWN ADAPTER");
-			//}
+			
 			LinearLayout customBar = (LinearLayout) actionBar.getCustomView();
 			TextView header = (TextView) customBar.findViewById(R.id.activity_name);
 			switch (motionEvent.getAction()) {
@@ -122,8 +122,18 @@ public class EndlessScroller extends ListActivity implements OnScrollListener {
 					header.setText("STEAMnet");
 					dy = motionEvent.getY();
 					if (dy - y > 250) {
-						//filterSettings.sparkBoxChange('Q');
-						new RefreshXJawns(50, gridview, indexgrid, context, filterSettings.getSparkBoxVal(), filterSettings.getIdeaBoxVal()); 
+						if (filterSettings.getCheckedRadioButton() == R.id.recentJawnsRadio)
+							new RefreshXJawns(50, gridview, indexgrid, context, filterSettings.getSparkBoxVal(), filterSettings.getIdeaBoxVal());
+						else if (filterSettings.getCheckedRadioButton() == R.id.randomJawnsRadio) {
+							boolean s = filterSettings.getSparkBoxVal(), i = filterSettings.getIdeaBoxVal();
+							filterSettings.getRecentRB().toggle();
+							if (s && i)
+								new GetXJawns(50, gridview, indexgrid, context);
+							else if (s && !i)
+								new GetXSparks(50, gridview, indexgrid, context);
+							else if (!s && i)
+								new GetXIdeas(50, gridview, indexgrid, context);
+						}
 						refreshed = true;
 					} else if (dy > y) {
 						main.getSparkEventHandler().initializeIndexGridLayout();

--- a/android/src/org/friendscentral/steamnet/FilterSettings.java
+++ b/android/src/org/friendscentral/steamnet/FilterSettings.java
@@ -23,6 +23,8 @@ import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.GridView;
 import android.widget.LinearLayout;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -208,6 +210,15 @@ public class FilterSettings {
 	
 	public boolean getIdeaBoxVal() {
 		return ideaBox.isChecked();
+	}
+	
+	public int getCheckedRadioButton() {
+		RadioGroup rg = (RadioGroup) mainLayout.findViewById(R.id.sortingRadioButtons);
+		return rg.getCheckedRadioButtonId();
+	}
+	
+	public RadioButton getRecentRB() {
+		return (RadioButton) mainLayout.findViewById(R.id.recentJawnsRadio);
 	}
 	
 	public void randomizeJawns() {

--- a/android/src/org/friendscentral/steamnet/JawnAdapter.java
+++ b/android/src/org/friendscentral/steamnet/JawnAdapter.java
@@ -1,13 +1,15 @@
 package org.friendscentral.steamnet;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 
 import org.friendscentral.steamnet.Activities.MainActivity;
 import org.friendscentral.steamnet.BaseClasses.Idea;
 import org.friendscentral.steamnet.BaseClasses.Jawn;
 import org.friendscentral.steamnet.BaseClasses.Spark;
 
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
@@ -298,10 +300,16 @@ public class JawnAdapter extends BaseAdapter {
 			    	sparkInfo.addView(userInfo);
 			    	
 			    	//Attach date info:
-			    	String date = spark.getDate();
+			    	String dateString = spark.getDate();
 			    	TextView dateInfo = new TextView(mContext);
-			    	dateInfo.setText(date);
-			    	sparkInfo.addView(dateInfo);
+					try {
+						Date date = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").parse(dateString);
+						String formattedDate = new SimpleDateFormat("h:ma; MMMM dd, yyyy").format(date);
+				    	dateInfo.setText(formattedDate);
+					} catch (ParseException e) {
+						dateInfo.setText("Unknown date");
+					}
+					sparkInfo.addView(dateInfo);
 			    	
 			    	//Attach ribbon:
 			    	ImageView ribbon = new ImageView(mContext);

--- a/android/src/org/friendscentral/steamnet/JawnAdapter.java
+++ b/android/src/org/friendscentral/steamnet/JawnAdapter.java
@@ -191,18 +191,24 @@ public class JawnAdapter extends BaseAdapter {
 		    		contentView = frameLayout;
 		    		
 		    	} else if (con == "T".charAt(0)) {
+		    		FrameLayout frameLayout = new FrameLayout(mContext);
+			        frameLayout.setLayoutParams(new FrameLayout.LayoutParams(image_size, image_size));
+			        frameLayout.setBackgroundResource(R.drawable.spark_content_bg);
+			        frameLayout.setPadding(4, 4, 4, 4);
+		    		
 		    		TextView textview;
 			        textview = new TextView(mContext);
 			        textview.setLayoutParams(new FrameLayout.LayoutParams(image_size, image_size));
-			        textview.setPadding(8, 8, 8, 8);
+			        textview.setPadding(4, 4, 4, 4);
 			        textview.setTextSize(20);
-			        textview.setBackgroundResource(R.drawable.spark_content_bg);
 		    		
 		    		String content = spark.getContent();
 		    		textview.setText(content.toCharArray(), 0, Math.min(200, content.length()));
 		    		
+		    		frameLayout.addView(textview);
+		    		
 		    		//multimediaLoaded.set(position, true);
-		    		contentView = textview;
+		    		contentView = frameLayout;
 		    		
 		    	} else if (con == "C".charAt(0)) {
 		    		/*


### PR DESCRIPTION
Refreshing algorithm now improved. Instead of destroying all of the loaded Jawns and fetching the most recent from the database, the app continually fetches the most recent Jawns until it finds one that matches the first Jawn in the gridview. This way, the ones that are loaded are kept and simply have their indices shifted.

This new refreshing function now is called after loading Jawns from cache on startup.

Also fixed the Spark posting bug, which disallowed Sparks with any tags from being posted.

Date formatting is also included in there somewhere as well. I'd like the explore the PrettyTime library in depth sometime though.
